### PR TITLE
Add message for safari users to enable WebGL2 feature and reload the page

### DIFF
--- a/src/js/View.js
+++ b/src/js/View.js
@@ -80,7 +80,12 @@ export let View = (function() {
                 'kernel': kernel,
                 'colormaps': colormaps,
             };
-            this.aladin.webglAPI = new Aladin.wasmLibs.webgl.WebClient(this.aladinDiv.id, shaders, resources);
+
+            try {
+                this.aladin.webglAPI = new Aladin.wasmLibs.webgl.WebClient(this.aladinDiv.id, shaders, resources);
+            } catch(e) {
+                alert("It may be possible that WebGL2 is not supported by default on your browser (Safari concerned).\nPlease enable it by checking:\nDeveloper Menu > Experimental Features > WebGL2 and reload the page.")
+            }
 
             this.location = location;
             this.fovDiv = fovDiv;

--- a/src/js/View.js
+++ b/src/js/View.js
@@ -73,18 +73,22 @@ export let View = (function() {
             // Init the WebGL context
             // At this point, the view has been created so the image canvas too
             let shaders = loadShaders();
-            //console.log(shaders);
         
-            // Start our Rust application. You can find `WebClient` in `src/lib.rs`
             let resources = {
                 'kernel': kernel,
                 'colormaps': colormaps,
             };
 
             try {
+                // Start our Rust application. You can find `WebClient` in `src/lib.rs`
                 this.aladin.webglAPI = new Aladin.wasmLibs.webgl.WebClient(this.aladinDiv.id, shaders, resources);
             } catch(e) {
-                alert("It may be possible that WebGL2 is not supported by default on your browser (Safari concerned).\nPlease enable it by checking:\nDeveloper Menu > Experimental Features > WebGL2 and reload the page.")
+                // For browsers not supporting WebGL2:
+                // 1. Print the original exception message in the console
+                console.log(e)
+                // 2. Add a more explicite message to the end user
+                alert("WebGL2 is not supported by default in your browser. If you're using Safari, you can enable it by checking:\nDeveloper Menu > Experimental Features > WebGL2. You will have to reload the page afterwards.")
+                // TODO: 3. propose a another possibility to the user: a button to run aladin lite v2 instead
             }
 
             this.location = location;


### PR DESCRIPTION
@tboch @fxpineau - This is a PR that tells the user to enable WebGL2 in Safari.

When not enabled, Rust raises an exception that is converted to a js cachable exception.
We could extend the js handling error to, for example, propose to the user to run Aladin Lite V2.