### PR TITLE
Resolve hover footprints

### DIFF
--- a/examples/al-footprints.html
+++ b/examples/al-footprints.html
@@ -13,7 +13,7 @@
     let aladin;
     A.init.then(() => {
         // Start up Aladin Lite
-        aladin = A.aladin('#aladin-lite-div', {survey: "CDS/P/DSS2/color", target: 'M 1', fov: 0.2});
+        aladin = A.aladin('#aladin-lite-div', {survey: "CDS/P/DSS2/color", target: 'M 1', fov: 0.2, showContextMenu: true, fullScreen: true});
         var overlay = A.graphicOverlay({color: '#ee2345', lineWidth: 3});
         aladin.addOverlay(overlay);
         overlay.addFootprints([
@@ -33,7 +33,7 @@
             console.log("footprint hovered catched", footprint)
         })
 
-        const cat = A.catalogFromVizieR('B/assocdata/obscore', 'M 1', 1, {onClick: 'showTable'});
+        const cat = A.catalogFromVizieR('B/assocdata/obscore', 'M 1', 100, {onClick: 'showTable', limit: 1000});
         aladin.addCatalog(cat);
     });
 </script>

--- a/examples/al-footprints.html
+++ b/examples/al-footprints.html
@@ -23,12 +23,18 @@
         ]);
         overlay.add(A.circle(83.66067, 22.03081, 0.04, {color: 'cyan'})); // radius in degrees
 
-        aladin.on("footprintClicked", (e) => {
-            console.log("footprint clicked catched")
+        aladin.on("footprintClicked", (footprint) => {
+            console.log("footprint clicked catched", footprint)
         })
-        aladin.on("objectClicked", (e) => {
-            console.log("object clicked catched")
+        aladin.on("objectClicked", (object) => {
+            console.log("object clicked catched", object)
         })
+        aladin.on("footprintHovered", (footprint) => {
+            console.log("footprint hovered catched", footprint)
+        })
+
+        const cat = A.catalogFromVizieR('B/assocdata/obscore', 'M 1', 1, {onClick: 'showTable'});
+        aladin.addCatalog(cat);
     });
 </script>
 </body>

--- a/src/js/Circle.js
+++ b/src/js/Circle.js
@@ -97,7 +97,9 @@ export let Circle = (function() {
         }
     };
 
-
+    Circle.prototype.isFootprint = function() {
+        return true;
+    }
 
     Circle.prototype.setCenter = function(centerRaDec) {
         this.centerRaDec = centerRaDec;

--- a/src/js/Circle.js
+++ b/src/js/Circle.js
@@ -30,8 +30,7 @@
 
 import { Utils } from "./Utils.js";
 import { AladinUtils } from "./AladinUtils.js";
-import { CooFrameEnum } from "./CooFrameEnum.js";
-import { Aladin } from "./Aladin.js";
+import { Overlay } from "./Overlay.js";
 
 // TODO : Circle and Footprint should inherit from the same root object
 export let Circle = (function() {
@@ -51,6 +50,27 @@ export let Circle = (function() {
 
     	this.isShowing = true;
     	this.isSelected = false;
+        this.selectionColor = undefined;
+    };
+
+    Circle.prototype.setColor = function(color) {
+        if (this.color == color) {
+            return;
+        }
+        this.color = color;
+        if (this.overlay) {
+            this.overlay.reportChange();
+        }
+    };
+
+    Circle.prototype.setSelectionColor = function(color) {
+        if (this.selectionColor == color) {
+            return;
+        }
+        this.selectionColor = color;
+        if (this.overlay) {
+            this.overlay.reportChange();
+        }
     };
 
     Circle.prototype.setOverlay = function(overlay) {
@@ -128,6 +148,10 @@ export let Circle = (function() {
             // we do not draw it
             return;
         }
+        this.center = {
+            x: centerXyview[0],
+            y: centerXyview[1],
+        };
         // compute value of radius in pixels in current projection
         var ra = this.centerRaDec[0];
         var dec = this.centerRaDec[1] + (ra>0 ? - this.radiusDegrees : this.radiusDegrees);
@@ -138,9 +162,9 @@ export let Circle = (function() {
             // we do not draw it
             return;
         }
-        var dx = circlePtXyView[0] - centerXyview[0];
-        var dy = circlePtXyView[1] - centerXyview[1];
-        var radiusInPix = Math.sqrt(dx*dx + dy*dy);
+        var dx = circlePtXyView[0] - this.center.x;
+        var dy = circlePtXyView[1] - this.center.y;
+        this.radius = Math.sqrt(dx*dx + dy*dy);
 
         // TODO : check each 4 point until show
         var baseColor = this.color;
@@ -152,14 +176,18 @@ export let Circle = (function() {
         }
 
         if (this.isSelected) {
-            ctx.strokeStyle = Overlay.increaseBrightness(baseColor, 50);
+            if(this.selectionColor) {
+                ctx.strokeStyle = this.selectionColor;
+            } else {
+                ctx.strokeStyle = Overlay.increaseBrightness(baseColor, 50);
+            }
         }
         else {
             ctx.strokeStyle = baseColor;
         }
 
         ctx.beginPath();
-        ctx.arc(centerXyview[0], centerXyview[1], radiusInPix, 0, 2*Math.PI, false);
+        ctx.arc(this.center.x, this.center.y, this.radius, 0, 2*Math.PI, false);
         if (!noStroke) {
             if (this.fillColor) {
                 ctx.fillStyle = this.fillColor;
@@ -168,6 +196,31 @@ export let Circle = (function() {
             ctx.stroke();
         }
     };
+
+    Circle.prototype.isInStroke = function(ctx, view, x, y) {
+        this.draw(ctx, view, true);
+        return ctx.isPointInStroke(x, y);
+    };
+
+    // From StackOverflow: https://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection
+    Circle.prototype.intersectsBBox = function(x, y, w, h) {
+        const circleDistance = {
+            x: abs(this.center.x - x),
+            y: abs(this.center.y - y)
+        };
+
+        if (circleDistance.x > (w/2 + this.radius)) { return false; }
+        if (circleDistance.y > (h/2 + this.radius)) { return false; }
+
+        if (circleDistance.x <= (w/2)) { return true; } 
+        if (circleDistance.y <= (h/2)) { return true; }
+
+        const dx = circleDistance.x - w/2;
+        const dy = circleDistance.y - h/2;
+
+        const cornerDistanceSquared = dx*dx + dy*dy;
+        return (cornerDistanceSquared <= (this.radius*this.radius));
+    }
 
     return Circle;
 })();

--- a/src/js/Circle.js
+++ b/src/js/Circle.js
@@ -114,11 +114,11 @@ export let Circle = (function() {
     };
 
     // TODO
-    Circle.prototype.draw = function(ctx, view/*, noStroke*/) {
+    Circle.prototype.draw = function(ctx, view, noStroke) {
         if (! this.isShowing) {
             return;
         }
-        //noStroke = noStroke===true || false;
+        noStroke = noStroke===true || false;
 
         var centerXyview = AladinUtils.radecToViewXy(this.centerRaDec[0], this.centerRaDec[1], view);
         if (!centerXyview) {
@@ -158,15 +158,13 @@ export let Circle = (function() {
 
         ctx.beginPath();
         ctx.arc(centerXyview[0], centerXyview[1], radiusInPix, 0, 2*Math.PI, false);
-        /*if (!noStroke) {
+        if (!noStroke) {
             if (this.fillColor) {
                 ctx.fillStyle = this.fillColor;
                 ctx.fill();
             }
             ctx.stroke();
-        }*/
-        ctx.stroke();
-
+        }
     };
 
     return Circle;

--- a/src/js/Ellipse.js
+++ b/src/js/Ellipse.js
@@ -129,6 +129,10 @@ export let Ellipse = (function() {
         }
     };
 
+    Ellipse.prototype.isFootprint = function() {
+        return true;
+    }
+
     // TODO
     Ellipse.prototype.draw = function(ctx, view, noStroke) {
         if (! this.isShowing) {

--- a/src/js/Ellipse.js
+++ b/src/js/Ellipse.js
@@ -30,8 +30,7 @@
 
 import { Utils } from "./Utils.js";
 import { AladinUtils } from "./AladinUtils.js";
-import { CooFrameEnum } from "./CooFrameEnum.js";
-import { Aladin } from "./Aladin.js";
+import { Overlay } from "./Overlay.js";
 
 // TODO : Ellipse, Circle and Footprint should inherit from the same root object
 export let Ellipse = (function() {
@@ -220,7 +219,16 @@ export let Ellipse = (function() {
             }
             ctx.stroke();
         }
-    }; 
+    };
+
+    Ellipse.prototype.isInStroke = function(ctx, view, x, y) {
+        this.draw(ctx, view, true);
+        return ctx.isPointInStroke(x, y);
+    };
+
+    Ellipse.prototype.intersectsBBox = function(x, y, w, h) {
+        // todo
+    };
     
     return Ellipse;
 })();

--- a/src/js/Ellipse.js
+++ b/src/js/Ellipse.js
@@ -40,6 +40,7 @@ export let Ellipse = (function() {
         options = options || {};
 
         this.color = options['color'] || undefined;
+        this.fillColor = options['fillColor'] || undefined;
 
         // TODO : all graphic overlays should have an id
         this.id = 'ellipse-' + Utils.uuidv4();
@@ -133,7 +134,6 @@ export let Ellipse = (function() {
         if (! this.isShowing) {
             return;
         }
-        noStroke = noStroke===true || false;
 
         var centerXyview = AladinUtils.radecToViewXy(this.centerRaDec[0], this.centerRaDec[1], view);
         if (!centerXyview) {
@@ -164,6 +164,8 @@ export let Ellipse = (function() {
             // We do not draw it
             return;
         }
+        noStroke = noStroke===true || false;
+
         // TODO : check each 4 point until show
         var baseColor = this.color;
         if (! baseColor && this.overlay) {
@@ -208,6 +210,10 @@ export let Ellipse = (function() {
         ctx.beginPath();
         ctx.ellipse(centerXyview[0], centerXyview[1], radiusInPixX, radiusInPixY, theta, 0, 2*Math.PI, false);
         if (!noStroke) {
+            if (this.fillColor) {
+                ctx.fillStyle = this.fillColor;
+                ctx.fill();
+            }
             ctx.stroke();
         }
     }; 

--- a/src/js/Footprint.js
+++ b/src/js/Footprint.js
@@ -1,0 +1,150 @@
+// Copyright 2015 - UDS/CNRS
+// The Aladin Lite program is distributed under the terms
+// of the GNU General Public License version 3.
+//
+// This file is part of Aladin Lite.
+//
+//    Aladin Lite is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, version 3 of the License.
+//
+//    Aladin Lite is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    The GNU General Public License is available in COPYING file
+//    along with Aladin Lite.
+//
+
+
+
+/******************************************************************************
+ * Aladin Lite project
+ *
+ * Class Polyline
+ *
+ * A Polyline is a graphical overlay made of several connected points
+ *
+ * TODO: Polyline and Circle should derive from a common base class
+ * TODO: index polyline, Circle in HEALPix pixels to avoid unneeded calls to draw
+ *
+ * Author: Thomas Boch[CDS], Matthieu Baumann[CDS]
+ *
+ *****************************************************************************/
+
+import { AladinUtils } from './AladinUtils.js';
+import { Utils } from './Utils.js';
+
+export let Footprint= (function() {
+    // constructor
+    let Footprint = function(shapes, source) {
+        // All graphics overlay have an id
+        this.id = 'footprint-' + Utils.uuidv4();
+
+        this.source = source;
+        this.shapes = shapes;
+    };
+
+    Footprint.prototype.setCatalog = function(catalog) {
+        if (this.source) {
+            this.source.setCatalog(catalog);
+        }
+    };
+
+    Footprint.prototype.show = function() {
+        this.shapes.forEach((shape) => shape.show())
+    };
+
+    Footprint.prototype.hide = function() {
+        this.shapes.forEach((shape) => shape.hide())
+    };
+
+    Footprint.prototype.select = function() {
+        this.shapes.forEach((shape) => shape.select())
+    };
+
+    Footprint.prototype.deselect = function() {
+        this.shapes.forEach((shape) => shape.deselect())
+    };
+
+    Footprint.prototype.setLineWidth = function(lineWidth) {
+        this.shapes.forEach((shape) => shape.setLineWidth())
+    };
+
+    Footprint.prototype.setColor = function(color) {
+        this.shapes.forEach((shape) => shape.setColor(color))
+    };
+
+    Footprint.prototype.setSelectionColor = function(color) {
+        this.shapes.forEach((shape) => shape.setSelectionColor(color))
+    };
+    
+    Footprint.prototype.isFootprint = function() {
+        return true;
+    }
+
+    Footprint.prototype.draw = function(ctx, view, noStroke) {
+        this.shapes.forEach((shape) => shape.draw(ctx, view, noStroke))
+    };
+
+    Footprint.prototype.actionClicked = function() {
+        if (this.source) {
+            this.source.actionClicked();
+        }
+
+        this.shapes.forEach((shape) => shape.select())
+    };
+
+    Footprint.prototype.actionOtherObjectClicked = function() {
+        if (this.source) {
+            this.source.actionOtherObjectClicked();
+        }
+
+        this.shapes.forEach((shape) => shape.deselect())
+    };
+
+    // If one shape is is stroke then the whole footprint is
+    Footprint.prototype.isInStroke = function(ctx, view, x, y) {
+        return this.shapes.some((shape) => shape.isInStroke(ctx, view, x, y));
+    };
+
+    Footprint.prototype.getCatalog = function() {
+        return this.source && this.source.catalog;
+    };
+
+    Footprint.prototype.intersectsBBox = function(x, y, w, h, view) {
+        if(this.source) {
+            let s = this.source;
+
+            if (!s.isShowing) {
+                return false;
+            }
+
+            let footprintCenter = null;
+            if (s.x && s.y) {
+                footprintCenter = {
+                    x: s.x,
+                    y: s.y,
+                };
+            } else {
+                var xy = AladinUtils.radecToViewXy(s.ra, s.dec, view);
+                if (!xy) {
+                    return false;
+                }
+
+                footprintCenter = {
+                    x: xy[0],
+                    y: xy[1],
+                };
+            }
+
+            if (footprintCenter.x >= x && footprintCenter.x <= x + w && footprintCenter.y >= y && footprintCenter.y <= y + h) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    return Footprint;
+})();

--- a/src/js/Line.js
+++ b/src/js/Line.js
@@ -65,6 +65,10 @@ export let Line = (function() {
         return false;
     };
 
+    Line.prototype.isFootprint = function() {
+        return false;
+    }
+
     Line.prototype.draw = function(ctx, noStroke) {
         noStroke = noStroke===true || false;
 

--- a/src/js/Line.js
+++ b/src/js/Line.js
@@ -65,9 +65,15 @@ export let Line = (function() {
         return false;
     };
 
-    Line.prototype.draw = function(ctx) {
+    Line.prototype.draw = function(ctx, noStroke) {
+        noStroke = noStroke===true || false;
+
         ctx.moveTo(this.x1, this.y1);
         ctx.lineTo(this.x2, this.y2);
+
+        if (!noStroke) {
+            ctx.stroke();
+        }
     };
 
     Line.intersectLine = function(x1, y1, x2, y2, x3, y3, x4, y4) {

--- a/src/js/Line.js
+++ b/src/js/Line.js
@@ -72,6 +72,7 @@ export let Line = (function() {
     Line.prototype.draw = function(ctx, noStroke) {
         noStroke = noStroke===true || false;
 
+        ctx.beginPath();
         ctx.moveTo(this.x1, this.y1);
         ctx.lineTo(this.x2, this.y2);
 
@@ -90,6 +91,15 @@ export let Line = (function() {
             return true;
         }
         return false;
+    };
+
+    Line.prototype.isInStroke = function(ctx, view, x, y) {
+        this.draw(ctx, view, true);
+        return ctx.isPointInStroke(x, y);
+    };
+
+    Line.prototype.intersectsBBox = function(x, y, w, h) {
+        // todo
     };
 
     return Line;

--- a/src/js/Overlay.js
+++ b/src/js/Overlay.js
@@ -31,6 +31,7 @@
  *****************************************************************************/
 
 import { AladinUtils } from "./AladinUtils.js";
+import { Footprint } from "./Footprint.js";
 import { Line } from './Line.js';
 import { Utils } from './Utils.js';
 

--- a/src/js/Polyline.js
+++ b/src/js/Polyline.js
@@ -120,7 +120,7 @@ export let Polyline= (function() {
         this.overlay.reportChange();
     };
     
-    Polyline.prototype.draw = function(ctx, view) {
+    Polyline.prototype.draw = function(ctx, view, noStroke) {
         if (! this.isShowing) {
             return;
         }
@@ -128,6 +128,8 @@ export let Polyline= (function() {
         if (! this.radecArray || this.radecArray.length<2) {
             return;
         }
+
+        noStroke = noStroke===true || false;
 
         var baseColor = this.color;
         if (! baseColor && this.overlay) {
@@ -159,12 +161,11 @@ export let Polyline= (function() {
 
         const lastVertexIdx = xyviewArray.length-1;
         ctx.moveTo(xyviewArray[0][0], xyviewArray[0][1]);
+
         for (var k=0, len=lastVertexIdx; k<len; k++) {
             const line = new Line(xyviewArray[k][0], xyviewArray[k][1], xyviewArray[k+1][0], xyviewArray[k+1][1]);
             if (line.isInsideView(view.width, view.height)) {
-                ctx.lineTo(xyviewArray[k+1][0], xyviewArray[k+1][1]);
-            } else {
-                ctx.moveTo(xyviewArray[k+1][0], xyviewArray[k+1][1]);
+                line.draw(ctx);
             }
         }
 
@@ -181,7 +182,9 @@ export let Polyline= (function() {
             }
         }
 
-        ctx.stroke();
+        if (!noStroke) {
+            ctx.stroke();
+        }
     };
 
     return Polyline;

--- a/src/js/Polyline.js
+++ b/src/js/Polyline.js
@@ -120,6 +120,11 @@ export let Polyline= (function() {
         this.overlay.reportChange();
     };
     
+    Polyline.prototype.isFootprint = function() {
+        // The polyline is a footprint if it describes a polygon (i.e. a closed polyline)
+        return this.closed;
+    }
+
     Polyline.prototype.draw = function(ctx, view, noStroke) {
         if (! this.isShowing) {
             return;

--- a/src/js/ProgressiveCat.js
+++ b/src/js/ProgressiveCat.js
@@ -494,6 +494,11 @@ export let ProgressiveCat = (function() {
             return this.rootUrl + "/" + "Norder" + norder + "/Dir" + dirIdx + "/Npix" + npix + ".tsv";
         },
     
+        // todo, allow HiPS cats to support footprints 
+        getFootprints: function() {
+            return null;
+        },
+
         loadNeededTiles: function() {
             if ( ! this.isShowing) {
                 return;

--- a/src/js/Source.js
+++ b/src/js/Source.js
@@ -52,6 +52,10 @@ export let Source = (function() {
         this.catalog = catalog;
     };
 
+    Source.prototype.getCatalog = function() {
+        return this.catalog;
+    };
+
     Source.prototype.show = function() {
         if (this.isShowing) {
             return;
@@ -135,7 +139,6 @@ export let Source = (function() {
                 this.catalog.onClick(this);
                 view.lastClickedObject = this;
             }
-
         }
     };
 

--- a/src/js/Source.js
+++ b/src/js/Source.js
@@ -139,6 +139,10 @@ export let Source = (function() {
         }
     };
 
+    Source.prototype.isFootprint = function() {
+        return false;
+    }
+
     Source.prototype.actionOtherObjectClicked = function() {
         if (this.catalog && this.catalog.onClick) {
             this.deselect();


### PR DESCRIPTION
This define a footprint object:
* footprint can only be created from what is found in a 's_region' column
* when footprint is found, do not draw the source,
* the selection is done based on the ra, dec source position. A better thing would be to implement bbox vs circle/line/polyline/ellipse intersection functions

This is fairly slow to loop over all the objects every time the mouse has moved. One should index the objects by HEALPix index to only retrieve the objects inside the view and loop over that. This is an enhancement to do later.