### PR TITLE
check for ccw order for every 3 vertices

### DIFF
--- a/examples/al-obscore.html
+++ b/examples/al-obscore.html
@@ -13,10 +13,13 @@
 
     let aladin;
     A.init.then(() => {
-        aladin = A.aladin('#aladin-lite-div', {target: '14 18 16.868 +56 44 29.37', fov: 5, showContextMenu: true});
+        aladin = A.aladin('#aladin-lite-div', {target: '14 18 16.868 +56 44 29.37', fov: 360, projection: 'AIT', showContextMenu: true});
 
         const c1 = A.catalogFromURL('https://raw.githubusercontent.com/bmatthieu3/SKA-Discovery-Service-Mockup/aladin/ObsCore/ObsCore_003.xml', {onClick: 'showTable'});
         aladin.addCatalog(c1);
+
+        const c2 = A.catalogFromVizieR('B/assocdata/obscore', '14 18 16.868 +56 44 29.37', 100, {onClick: 'showTable', limit: 1000});
+        aladin.addCatalog(c2);
     });
 </script>
 </body>


### PR DESCRIPTION
This PR relates to #63 

When drawing the polyline:
* Every 2 following edges are checked for it CCW order
* If there is a couple of edges having a CCW order, do not draw the whole polygon

We maybe would like to only not draw the crossing edges (not all the polygon) but this could be done for a future optimization.
