### PR TITLE
Added .npmignore to create aladin npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*/*
+!dist/
+!package.json


### PR DESCRIPTION
@bmatthieu3 I don't know how you published the current aladin-lite npm version, but I am not able to import it, I tested locally creating a @dngomez/aladin-lite version just packing the compiled dist directory and it worked fine.

I've added this .npmignore to pack just the desired files and then published.
In this case the steps are
- npm run build
- npm login
- npm pack
- npm publish --access public