### PR TITLE
update getViewWCS to adapt to projection

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,6 +1,7 @@
 unreleased
 - new method aladin.getFrame() that returns the name of the current coordinate system
 - `getViewWCS` now adapts to the `cooFrame` and the `projection`
+- `getFov` is no longer capped at 180°
 
 2020-08
 - polyline improvements (by @imbasimba)

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -2,6 +2,7 @@ unreleased
 - new method aladin.getFrame() that returns the name of the current coordinate system
 - `getViewWCS` now adapts to the `cooFrame` and the `projection`
 - `getFov` is no longer capped at 180°
+- bugfix `setProjecion` now also updates for 'PAR' and 'SFL' projections
 
 2020-08
 - polyline improvements (by @imbasimba)

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,5 +1,5 @@
 unreleased
-- new method aladin.getCooFrame() that returns the name of the current coordinate system
+- new method aladin.getFrame() that returns the name of the current coordinate system
 - `getViewWCS` now adapts to the `cooFrame` and the `projection`
 
 2020-08

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,3 +1,7 @@
+unreleased
+- new method aladin.getCooFrame() that returns the name of the current coordinate system
+- `getViewWCS` now adapts to the `cooFrame` and the `projection`
+
 2020-08
 - polyline improvements (by @imbasimba)
 

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -1593,9 +1593,8 @@ export let Aladin = (function () {
         var fovX = this.view.fov;
         var s = this.getSize();
         var fovY = s[1] / s[0] * fovX;
-        // TODO : take into account AITOFF projection where fov can be larger than 180
-        fovX = Math.min(fovX, 180);
-        fovY = Math.min(fovY, 180);
+        fovX = Math.min(fovX);
+        fovY = Math.min(fovY);
 
         return [fovX, fovY];
     };

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -713,6 +713,14 @@ export let Aladin = (function () {
         return projName;
     };
 
+    /** return the current coordinate system: possible values are 'J2000', 'J2000d', and 'Galactic' 
+     * @api
+     *
+     */
+    Aladin.prototype.getCooFrame = function() {
+        return this.view.cooFrame.label;
+    }
+
     /** point view to a given object (resolved by Sesame) or position
      * @api
      *
@@ -1437,23 +1445,36 @@ export let Aladin = (function () {
     Aladin.prototype.getViewWCS = function (options) {
         var raDec = this.getRaDec();
         var fov = this.getFov();
-        // TODO: support for other projection methods than SIN
+        var projectionName = this.getProjectionName();
+
+        // get the cootype prefix from the coordinate frame
+        switch (this.getCooFrame()) {
+            case "J2000":
+            case "J2000d":
+                var cooType1 = "RA---";
+                var cooType2 = "DEC---";
+                break;
+            case "Galactic":
+                var cooType1 = "GLON---";
+                var cooType2 = "GLAT---";
+        }
+
         return {
             NAXIS: 2,
             NAXIS1: this.view.width,
             NAXIS2: this.view.height,
-            RADECSYS: 'ICRS',
+            RADECSYS: "ICRS",
             CRPIX1: this.view.width / 2,
             CRPIX2: this.view.height / 2,
             CRVAL1: raDec[0],
             CRVAL2: raDec[1],
-            CTYPE1: 'RA---SIN',
-            CTYPE2: 'DEC--SIN',
+            CTYPE1: cooType1 + projectionName,
+            CTYPE2: cooType2 + projectionName,
             CD1_1: fov[0] / this.view.width,
             CD1_2: 0.0,
             CD2_1: 0.0,
             CD2_2: fov[1] / this.view.height
-        }
+        };
     }
 
     /** restrict FOV range

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -1459,6 +1459,12 @@ export let Aladin = (function () {
                 var cooType2 = "GLAT-";
         }
 
+        // treat the planetary body case
+        if (this.getBaseImageLayer().isPlanetaryBody())
+            var cd11 = fov[0] / this.view.width;
+        else
+            var cd11 = -fov[0] / this.view.width;
+
         return {
             NAXIS: 2,
             NAXIS1: this.view.width,
@@ -1470,7 +1476,7 @@ export let Aladin = (function () {
             CRVAL2: center[1],
             CTYPE1: cooType1 + projectionName,
             CTYPE2: cooType2 + projectionName,
-            CD1_1: -fov[0] / this.view.width,
+            CD1_1: cd11,
             CD1_2: 0.0,
             CD2_1: 0.0,
             CD2_2: fov[1] / this.view.height

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -1470,7 +1470,7 @@ export let Aladin = (function () {
             CRVAL2: center[1],
             CTYPE1: cooType1 + projectionName,
             CTYPE2: cooType2 + projectionName,
-            CD1_1: fov[0] / this.view.width,
+            CD1_1: -fov[0] / this.view.width,
             CD1_2: 0.0,
             CD2_1: 0.0,
             CD2_2: fov[1] / this.view.height

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -1443,7 +1443,7 @@ export let Aladin = (function () {
      * @API
     */
     Aladin.prototype.getViewWCS = function (options) {
-        var raDec = this.getRaDec();
+        var center = this.wasm.getCenter();
         var fov = this.getFov();
         var projectionName = this.getProjectionName();
 
@@ -1466,8 +1466,8 @@ export let Aladin = (function () {
             RADECSYS: "ICRS",
             CRPIX1: this.view.width / 2,
             CRPIX2: this.view.height / 2,
-            CRVAL1: raDec[0],
-            CRVAL2: raDec[1],
+            CRVAL1: center[0],
+            CRVAL2: center[1],
             CTYPE1: cooType1 + projectionName,
             CTYPE2: cooType2 + projectionName,
             CD1_1: fov[0] / this.view.width,

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -1452,11 +1452,11 @@ export let Aladin = (function () {
             case "J2000":
             case "J2000d":
                 var cooType1 = "RA---";
-                var cooType2 = "DEC---";
+                var cooType2 = "DEC--";
                 break;
             case "Galactic":
-                var cooType1 = "GLON---";
-                var cooType2 = "GLAT---";
+                var cooType1 = "GLON-";
+                var cooType2 = "GLAT-";
         }
 
         return {

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -717,7 +717,7 @@ export let Aladin = (function () {
      * @api
      *
      */
-    Aladin.prototype.getCooFrame = function() {
+    Aladin.prototype.getFrame = function() {
         return this.view.cooFrame.label;
     }
 
@@ -1448,7 +1448,7 @@ export let Aladin = (function () {
         var projectionName = this.getProjectionName();
 
         // get the cootype prefix from the coordinate frame
-        switch (this.getCooFrame()) {
+        switch (this.getFrame()) {
             case "J2000":
             case "J2000d":
                 var cooType1 = "RA---";

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -1593,9 +1593,6 @@ export let Aladin = (function () {
         var fovX = this.view.fov;
         var s = this.getSize();
         var fovY = s[1] / s[0] * fovX;
-        fovX = Math.min(fovX);
-        fovY = Math.min(fovY);
-
         return [fovX, fovY];
     };
 

--- a/src/js/ProjectionEnum.js
+++ b/src/js/ProjectionEnum.js
@@ -29,29 +29,29 @@
  *****************************************************************************/
 export let ProjectionEnum = {
    // Zenithal
-   TAN: {id: 1, fov: 180, longName: "gnomonic"},	  /* Gnomonic projection      */
-   STG: {id: 2, fov: 360, longName: "stereographic"},	  /* Stereographic projection */
-   SIN: {id: 3, fov: 180, longName: "orthographic"},	  /* Orthographic		         */
-   ZEA: {id: 4, fov: 360, longName: "zenital equal-area"},	  /* Equal-area 		         */
-   FEYE: {id: 5, fov: 190, longName: "fish eye"},
-   AIR: {id: 6, fov: 360, longName: "airy"},
+   TAN: {id: 1, fov: 180, label: "gnomonic"},	  /* Gnomonic projection      */
+   STG: {id: 2, fov: 360, label: "stereographic"},	  /* Stereographic projection */
+   SIN: {id: 3, fov: 180, label: "orthographic"},	  /* Orthographic		         */
+   ZEA: {id: 4, fov: 360, label: "zenital equal-area"},	  /* Equal-area 		         */
+   FEYE: {id: 5, fov: 190, label: "fish eye"},
+   AIR: {id: 6, fov: 360, label: "airy"},
    //AZP: {fov: 180},
-   ARC: {id: 7, fov: 360, longName: "zenital equidistant"},
-   NCP: {id: 8, fov: 180, longName: "north celestial pole"},
+   ARC: {id: 7, fov: 360, label: "zenital equidistant"},
+   NCP: {id: 8, fov: 180, label: "north celestial pole"},
    // Cylindrical
-   MER: {id: 9, fov: 360, longName: "mercator"},
-   CAR: {id: 10, fov: 360, longName: "plate carrée"},
-   CEA: {id: 11, fov: 360, longName: "cylindrical equal area"},
-   CYP: {id: 12, fov: 360, longName: "cylindrical perspective"},
+   MER: {id: 9, fov: 360, label: "mercator"},
+   CAR: {id: 10, fov: 360, label: "plate carrée"},
+   CEA: {id: 11, fov: 360, label: "cylindrical equal area"},
+   CYP: {id: 12, fov: 360, label: "cylindrical perspective"},
    // Pseudo-cylindrical
-   AIT: {id: 13, fov: 360, longName: "hammer-aitoff"},
-   PAR: {id: 14, fov: 360, longName: "parabolic"},
-   SFL: {id: 15, fov: 360, longName: "sanson-flamsteed"},
-   MOL: {id: 16, fov: 360, longName: "mollweide"},
+   AIT: {id: 13, fov: 360, label: "hammer-aitoff"},
+   PAR: {id: 14, fov: 360, label: "parabolic"},
+   SFL: {id: 15, fov: 360, label: "sanson-flamsteed"},
+   MOL: {id: 16, fov: 360, label: "mollweide"},
    // Conic
-   COD: {id: 17, fov: 360, longName: "conic equidistant"},
+   COD: {id: 17, fov: 360, label: "conic equidistant"},
    // Hybrid
-   HPX: {id: 19, fov: 360, longName: "healpix"},
+   HPX: {id: 19, fov: 360, label: "healpix"},
 };
 
 export let projectionNames = [

--- a/src/js/ProjectionEnum.js
+++ b/src/js/ProjectionEnum.js
@@ -29,29 +29,29 @@
  *****************************************************************************/
 export let ProjectionEnum = {
    // Zenithal
-   TAN: {id: 1, fov: 180},	  /* Gnomonic projection      */
-   STG: {id: 2, fov: 360},	  /* Stereographic projection */
-   SIN: {id: 3, fov: 180},	  /* Orthographic		         */
-   ZEA: {id: 4, fov: 360},	  /* Equal-area 		         */
-   FEYE: {id: 5, fov: 190},
-   AIR: {id: 6, fov: 360},
+   TAN: {id: 1, fov: 180, longName: "gnomonic"},	  /* Gnomonic projection      */
+   STG: {id: 2, fov: 360, longName: "stereographic"},	  /* Stereographic projection */
+   SIN: {id: 3, fov: 180, longName: "orthographic"},	  /* Orthographic		         */
+   ZEA: {id: 4, fov: 360, longName: "zenital equal-area"},	  /* Equal-area 		         */
+   FEYE: {id: 5, fov: 190, longName: "fish eye"},
+   AIR: {id: 6, fov: 360, longName: "airy"},
    //AZP: {fov: 180},
-   ARC: {id: 7, fov: 360},
-   NCP: {id: 8, fov: 180},
+   ARC: {id: 7, fov: 360, longName: "zenital equidistant"},
+   NCP: {id: 8, fov: 180, longName: "north celestial pole"},
    // Cylindrical
-   MER: {id: 9, fov: 360},
-   CAR: {id: 10, fov: 360},
-   CEA: {id: 11, fov: 360},
-   CYP: {id: 12, fov: 360},
+   MER: {id: 9, fov: 360, longName: "mercator"},
+   CAR: {id: 10, fov: 360, longName: "plate carrée"},
+   CEA: {id: 11, fov: 360, longName: "cylindrical equal area"},
+   CYP: {id: 12, fov: 360, longName: "cylindrical perspective"},
    // Pseudo-cylindrical
-   AIT: {id: 13, fov: 360},
-   PAR: {id: 14, fov: 360},
-   SFL: {id: 15, fov: 360},
-   MOL: {id: 16, fov: 360},
+   AIT: {id: 13, fov: 360, longName: "hammer-aitoff"},
+   PAR: {id: 14, fov: 360, longName: "parabolic"},
+   SFL: {id: 15, fov: 360, longName: "sanson-flamsteed"},
+   MOL: {id: 16, fov: 360, longName: "mollweide"},
    // Conic
-   COD: {id: 17, fov: 360},
+   COD: {id: 17, fov: 360, longName: "conic equidistant"},
    // Hybrid
-   HPX: {id: 19, fov: 360},
+   HPX: {id: 19, fov: 360, longName: "healpix"},
 };
 
 export let projectionNames = [

--- a/src/js/View.js
+++ b/src/js/View.js
@@ -1689,6 +1689,12 @@ export let View = (function () {
             case "AIT":
                 this.projection = ProjectionEnum.AIT;
                 break;
+            case "PAR":
+                this.projection = ProjectionEnum.PAR;
+                break;
+            case "SFL":
+                this.projection = ProjectionEnum.SFL;
+                break;
             // Cylindrical (MER, CAR, CEA, CYP)
             case "MER":
                 this.projection = ProjectionEnum.MER;

--- a/src/js/gui/ProjectionSelector.js
+++ b/src/js/gui/ProjectionSelector.js
@@ -29,7 +29,7 @@
  *****************************************************************************/
 
  import { ALEvent } from "../events/ALEvent.js";
- import { projectionNames } from "../ProjectionEnum.js";
+ import { projectionNames, ProjectionEnum } from "../ProjectionEnum.js";
  import $ from 'jquery';
 
  export class ProjectionSelector {
@@ -55,7 +55,7 @@
         this.selectProjection.empty();
         
         projectionNames.forEach(p => {
-            this.selectProjection.append($("<option />").val(p).text(p));
+            this.selectProjection.append($("<option />").val(p).text(p).attr("title", ProjectionEnum[p].longName));
         });
         let self = this;
         this.selectProjection.change(function () {

--- a/src/js/gui/ProjectionSelector.js
+++ b/src/js/gui/ProjectionSelector.js
@@ -55,7 +55,7 @@
         this.selectProjection.empty();
         
         projectionNames.forEach(p => {
-            this.selectProjection.append($("<option />").val(p).text(p).attr("title", ProjectionEnum[p].longName));
+            this.selectProjection.append($("<option />").val(p).text(p).attr("title", ProjectionEnum[p].label));
         });
         let self = this;
         this.selectProjection.change(function () {


### PR DESCRIPTION
This is an adaptation of the method `getViewWCS` so that is also works for projections that are not "SIN". 

## What's new

new in API: 
```js
aladin.getCooFrame()
```
This new function returns the current cooFrame of the view. The retruned values can be "J2000", "J2000d", "Galactic" and are taken from the label returned by `aladin.view.cooframe`

## What changed
```js
aladin.getViewWCS()
```
now adapts to the projection and coordinate system in the keys `CTYPE1` and `CTYPE2` rather than always returning `RA---SIN` and `DEC`

## What needs to be reviewed

Check that this is the expected output. Example: 

"Galactic"

```
CD1_1: 0.018111371257799755
CD1_2: 0
​CD2_1: 0
​CD2_2: 0.018111371257799755
​CRPIX1: 1280
​CRPIX2: 378
​CRVAL1: 326.8736386214195
​CRVAL2: 7.499153148417243
​CTYPE1: "GLON-AIT"
​CTYPE2: "GLAT-AIT"
​NAXIS: 2
​NAXIS1: 2560
​NAXIS2: 756
​RADECSYS: "ICRS"
```

"J2000d"

```
CD1_1: 0.018111371257799755
CD1_2: 0
CD2_1: 0
CD2_2: 0.018111371257799755
CRPIX1: 1280
CRPIX2: 378
CRVAL1: 326.8736386214195
CRVAL2: 7.4991531484172445
CTYPE1: "RA---STG"
CTYPE2: "DEC--STG"
NAXIS: 2
NAXIS1: 2560
NAXIS2: 756
RADECSYS: "ICRS"
```