### PR TITLE
Fixes the grid options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.3.0
 
+* [style] The default grid color is now `rgb(178, 50, 178)` to fit the classic Aladin color palette
+* [feat] The object of grid options `gridOptions` is now available in the public API
+* [fixed] The parameters `gridColor` and `gridOpacity`, `gridOptions.showLabels` now work as expected
 * New documentation API (W.I.P) here: <https://cds-astro.github.io/aladin-lite/>
 * New release page here: <https://aladin.cds.unistra.fr/AladinLite/doc/release/>
 * A major UI update by @bmatthieu3

--- a/src/core/src/grid/mod.rs
+++ b/src/core/src/grid/mod.rs
@@ -102,6 +102,7 @@ impl ProjetedGrid {
 
         if let Some(opacity) = opacity {
             self.color.a = opacity;
+            self.text_renderer.set_color(&self.color);
         }
 
         if let Some(thickness) = thickness {
@@ -213,7 +214,7 @@ impl ProjetedGrid {
         rasterizer.add_stroke_paths(paths, self.thickness, &self.color, &self.line_style);
 
         // update labels
-        {
+        if self.show_labels {
             let labels = meridians
                 .iter()
                 .filter_map(|m| m.get_label())

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -103,8 +103,20 @@ import { Toolbar } from './gui/Widgets/Toolbar';
  * @property {boolean} [fullScreen=false] - Whether to start in full-screen mode.
  * @property {string} [reticleColor="rgb(178, 50, 178)"] - Color of the reticle in RGB format.
  * @property {number} [reticleSize=22] - Size of the reticle.
- * @property {string} [gridColor="rgb(0, 255, 0)"] - Color of the grid in RGB format.
- * @property {number} [gridOpacity=0.5] - Opacity of the grid (0 to 1).
+ * 
+ * @property {string} [gridColor="rgb(178, 50, 178)"] - Color of the grid in RGB format. 
+ *                                                      Is overshadowed by gridOptions.color if defined.
+ * @property {number} [gridOpacity=0.8] - Opacity of the grid (0 to 1). 
+ *                                        Is overshadowed by gridOptions.opacity if defined.
+ * @property {Object} [gridOptions] - More options for the grid.
+ * @property {string} [gridOptions.color="rgb(178, 50, 178)"] - Color of the grid. Can be specified as a named color 
+ *                    (see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/named-color| named colors}),
+ *                    as rgb (ex: "rgb(178, 50, 178)"), or as a hex color (ex: "#86D6AE").              
+ * @property {number} [gridOptions.thickness=2] - The thickness of the grid, in pixels.
+ * @property {number} [gridOptions.opacity=0.8] - Opacity of the grid and labels. It is comprised between 0 and 1.
+ * @property {boolean} [gridOptions.showLabels=true] - Whether the grid has labels.
+ * @property {number} [gridOptions.labelSize=15] - The font size of the labels.
+ * 
  * @property {string} [projection="SIN"] - Projection type.
  * @property {boolean} [log=true] - Whether to log events.
  * @property {boolean} [samp=false] - Whether to enable SAMP (Simple Application Messaging Protocol).
@@ -204,13 +216,15 @@ export let Aladin = (function () {
         // Grid
         let gridOptions = {
             enabled: false,
-            color: (options.gridOptions && options.gridOptions.color && Color.hexToRgb(options.gridOptions.color)) || Aladin.DEFAULT_OPTIONS.gridColor,
-            opacity: (options.gridOptions && options.gridOptions.opacity) || Aladin.DEFAULT_OPTIONS.gridOpacity
+            color: options.gridOptions.color ? options.gridOptions.color : options.gridColor,
+            opacity: options.gridOptions.opacity || options.gridOpacity,
+            showLabels: options.gridOptions.showLabels === undefined ? true : options.gridOptions.showLabels,
+            thickness: options.gridOptions.thickness || 2,
+            labelSize: options.gridOptions.labelSize || 15,
         };
         if (options && options.showCooGrid) {
             gridOptions.enabled = true;
         }
-
         this.setCooGrid(gridOptions);
 
         // Set the projection
@@ -238,7 +252,7 @@ export let Aladin = (function () {
         this.gotoObject(options.target, undefined);
 
         if (options.log) {
-            var params = requestedOptions;
+            var params = options;
             params['version'] = Aladin.VERSION;
             Logger.log("startup", params);
         }
@@ -541,8 +555,9 @@ export let Aladin = (function () {
         fullScreen: false,
         reticleColor: "rgb(178, 50, 178)",
         reticleSize: 22,
-        gridColor: "rgb(0, 255, 0)",
-        gridOpacity: 0.5,
+        gridColor: "rgb(178, 50, 178)",
+        gridOpacity: 0.8,
+        gridOptions: {},
         projection: 'SIN',
         log: true,
         samp: false,

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -167,8 +167,20 @@ export let Aladin = (function () {
             delete requestedOptions.zoom;
             requestedOptions.fov = fovValue;
         }
+
         // merge with default options
-        var options = {};
+        var options = {
+            gridOptions: {}
+        };
+
+        // 'gridOptions' is an object, so it need it own loop
+        if ('gridOptions' in requestedOptions) {
+            for (var key in Aladin.DEFAULT_OPTIONS.gridOptions) {
+                if (requestedOptions.gridOptions[key] === undefined) {
+                    options.gridOptions[key] = Aladin.DEFAULT_OPTIONS.gridOptions[key]
+                }
+            }
+        }
         for (var key in Aladin.DEFAULT_OPTIONS) {
             if (requestedOptions[key] !== undefined) {
                 options[key] = requestedOptions[key];
@@ -214,14 +226,11 @@ export let Aladin = (function () {
         }
 
         // Grid
-        let gridOptions = {
-            enabled: false,
-            color: options.gridOptions.color ? options.gridOptions.color : options.gridColor,
-            opacity: options.gridOptions.opacity || options.gridOpacity,
-            showLabels: options.gridOptions.showLabels === undefined ? true : options.gridOptions.showLabels,
-            thickness: options.gridOptions.thickness || 2,
-            labelSize: options.gridOptions.labelSize || 15,
-        };
+        let gridOptions = options.gridOptions;
+        // color and opacity can be defined by two variables. The item in gridOptions
+        // should take precedence.
+        gridOptions["color"] = options.gridOptions.color || options.gridColor;
+        gridOptions["opacity"] = options.gridOptions.opacity || options.gridOpacity;
         if (options && options.showCooGrid) {
             gridOptions.enabled = true;
         }
@@ -557,7 +566,12 @@ export let Aladin = (function () {
         reticleSize: 22,
         gridColor: "rgb(178, 50, 178)",
         gridOpacity: 0.8,
-        gridOptions: {},
+        gridOptions: {
+            enabled: false,
+            showLabels: true,
+            thickness: 2,
+            labelSize: 15
+        },
         projection: 'SIN',
         log: true,
         samp: false,


### PR DESCRIPTION
## What the PR does

- the parameters gridColor and gridOpacity are no longer ignored (it was reading `Aladin.DEFAULT_OPTIONS` instead of the user options)
- add gridOptions to the API description
- expose `showLabels`, `thickness` and `labelSize` to the users `AladinOptions` API (they could only be changed in the GUI, but not at startup)
- edit default values for the grid to fit the aladin style a bit better