### PR TITLE
test: add initialization of aladin with default parameters test

### DIFF
--- a/tests/unit/Aladin.test.js
+++ b/tests/unit/Aladin.test.js
@@ -1,0 +1,15 @@
+import { A } from '../../src/js/A.js';
+import { expect } from 'vitest';
+import { Window } from 'happy-dom';
+
+it("Initializes Aladin with default parameters", () => {
+    const window = new Window({ url: 'https://localhost:8080' });
+    const document = window.document;
+    document.body.innerHTML = '<div id="aladin-lite-div" style="width: 500px; height: 500px"></div>';
+    A.init.then( () => {
+        A.aladin("#aladin-lite-div");
+    }
+    )
+    expect(window).toMatchSnapshot();
+    window.close();
+})


### PR DESCRIPTION
## What the PR does

It tries to add a very basic test where an Aladin instance with default parameters is created in a window and this should match a snapshot.

## Why it is in draft state

Running 

```sh
npm run test:unit
```

Lead to the following failure:

```
 FAIL  tests/unit/Aladin.test.js [ tests/unit/Aladin.test.js ]
Error: Failed to resolve entry for package "/home/manon.marchand/Documents/cds-astro-github/aladin-lite/src/core/pkg". The package may have incorrect main/module/exports specified in its package.json.
 ❯ packageEntryFailure node_modules/vite/dist/node/chunks/dep-52909643.js:28725:11
 ❯ resolvePackageEntry node_modules/vite/dist/node/chunks/dep-52909643.js:28722:5
 ❯ tryCleanFsResolve node_modules/vite/dist/node/chunks/dep-52909643.js:28381:28
 ❯ tryFsResolve node_modules/vite/dist/node/chunks/dep-52909643.js:28328:17
 ❯ Context.resolveId node_modules/vite/dist/node/chunks/dep-52909643.js:28153:28
 ❯ Object.resolveId node_modules/vite/dist/node/chunks/dep-52909643.js:44276:64
 ❯ TransformContext.resolve node_modules/vite/dist/node/chunks/dep-52909643.js:43992:23
 ❯ normalizeUrl node_modules/vite/dist/node/chunks/dep-52909643.js:41836:34
 ❯ async file:/home/manon.marchand/Documents/cds-astro-github/aladin-lite/node_modules/vite/dist/node/chunks/dep-52909643.js:41998:47
```

@onekiloparsec : thanks a lot for setting up the first test in this repo. I read through vittest documentation, and I'd like to add more tests, but I'm stuck. Would you have any pointers on how to make this one work?