### PR TITLE
upgrade vite-to-level-await

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vite": "^4.3.8",
     "vite-plugin-css-injected-by-js": "^3.1.1",
     "vite-plugin-glsl": "^1.1.2",
-    "vite-plugin-top-level-await": "^1.3.1",
+    "vite-plugin-top-level-await": "^1.4.1",
     "vite-plugin-wasm": "^3.2.2",
     "vite-plugin-wasm-pack": "^0.1.12",
     "vitest": "^0.32.2"


### PR DESCRIPTION
~This PR switches to reference stable versions of `healpix` and `moc` libraries~

This was done in commit 93a7c7c6425bf1b2d735e235af22cda640772429 .

This PR only upgrades the vite-top-level-await dependency now

Fixes #159 