### PR TITLE
Issue #235: combine requestedOptions and Aladin.DEFAULT_OPTIONS with spread operator

### DIFF
--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -301,10 +301,16 @@ export let Aladin = (function () {
         var options = {
             ...Aladin.DEFAULT_OPTIONS,
             ...requestedOptions,
+            // In javascript, arrays like objects are copied by reference.
+            // To not change the default aladin options afterwards,
+            // we use the spread operator to create a new object for the gridOptions property
             gridOptions:{
                 ...Aladin.DEFAULT_OPTIONS.gridOptions,
                 ...requestedOptions.gridOptions
-            }
+            },
+            // and use the slice method to create a new array for the hipsList property:
+            // https://stackoverflow.com/questions/7486085/copy-array-by-value
+            hipsList: requestedOptions.hipsList || Aladin.DEFAULT_OPTIONS.hipsList.slice()
         };
 
         this.options = options;

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -298,31 +298,14 @@ export let Aladin = (function () {
         }
 
         // merge with default options
-        var options = {};
-
-        for (var key in Aladin.DEFAULT_OPTIONS) {
-            if (requestedOptions[key] !== undefined) {
-                options[key] = requestedOptions[key];
-            } else {
-                options[key] = Aladin.DEFAULT_OPTIONS[key];
+        var options = {
+            ...Aladin.DEFAULT_OPTIONS,
+            ...requestedOptions,
+            gridOptions:{
+                ...Aladin.DEFAULT_OPTIONS.gridOptions,
+                ...requestedOptions.gridOptions
             }
-        }
-
-        // 'gridOptions' is an object, so it need it own loop
-        if ("gridOptions" in requestedOptions) {
-            for (var key in Aladin.DEFAULT_OPTIONS.gridOptions) {
-                if (requestedOptions.gridOptions[key] === undefined) {
-                    options.gridOptions[key] =
-                        Aladin.DEFAULT_OPTIONS.gridOptions[key];
-                }
-            }
-        }
-
-        for (var key in requestedOptions) {
-            if (Aladin.DEFAULT_OPTIONS[key] === undefined) {
-                options[key] = requestedOptions[key];
-            }
-        }
+        };
 
         this.options = options;
 


### PR DESCRIPTION
# What is changing?
combine `requsetedOptions` and `Aladin.DEFAULT_OPTIONS` with spread operator

# Why is this change needed?
There is a bug in the Aladin initializer that causes the `Aladin.DEFAULT_OPTIONS` to be passed by reference throughout the code. This causes the constant to be overwritten by other functions within the Aladin object, specifically the `Aladin.DEFAULT_OPTIONS.GridOptions.color` value being modified by the `setCooGrid` method. This leads to the apparent disappearance of the grid under specific workflows where the Aladin initializer is reran. See related issue ticket for more information https://github.com/cds-astro/aladin-lite/issues/235.

By using the spread operator to combine the `Aladin.DEFAULT_OPTIONS` and `requestedOptions` objects, we ensure that all values are options are passed by value instead of by reference. 

# How was this change tested?
This change was tested through a Vue application that embeds the aladin-lite widget. This is how the bug was identified and the change resolves the issue.

Manual testing was performed on the demos provided in  `/examples` and all features worked as expected. I was unable to replicate the bug using any of the examples, so I would highly suggest more thorough testing is done by someone with more experience with the tool than myself to sanity check that there are no adverse effects. 

# Related issue 
A in-depth write up of the issue included at the following issue link https://github.com/cds-astro/aladin-lite/issues/235