### PR TITLE
feat: flip longitude axis global method on Aladin

### DIFF
--- a/examples/al-additive-blend.html
+++ b/examples/al-additive-blend.html
@@ -10,6 +10,8 @@ import A from '../src/js/A.js';
 A.init.then(() => {
     let aladin = A.aladin('#aladin-lite-div', {projection: "TAN", survey: "P/HSC/DR2/deep/g", target: '02 21 36.529 -05 31 20.16', fov: 0.1});
 
+    aladin.reverseLongitude(true)
+
     let hscGreenSurvey = aladin.getBaseImageLayer();
     hscGreenSurvey.setImageFormat("fits");
     hscGreenSurvey.setColormap("green", { stretch: "asinh" });

--- a/examples/al-animation-CS-CDS-2022.html
+++ b/examples/al-animation-CS-CDS-2022.html
@@ -201,7 +201,7 @@
 
         let stephansNIRCamMIRI
         async function s11() {
-            stephansNIRCamMIRI = aladin.createImageSurvey('CDS/P/JWST/Stephans-Quintet/NIRCam+MIRI', "stephansMIRI", null, null, null)
+            stephansNIRCamMIRI = aladin.createImageSurvey('CDS/P/JWST/Stephans-Quintet/NIRCam-MIRI', "stephansNircamMIRI", null, null, null)
             stephansNIRCamMIRI.setOpacity(0.0)
             aladin.setOverlayImageLayer(stephansNIRCamMIRI, 'stephansNIRCamMIRI')
 

--- a/examples/al-coronelli.html
+++ b/examples/al-coronelli.html
@@ -23,6 +23,7 @@
 <script src="https://code.jquery.com/jquery-1.10.1.min.js"></script>
 <script type="text/javascript">
     let aladin;
+    let longitudeReversed = false;
 </script>
 <div id="aladin-lite-div" style="width:100vw;height:100vh;">
     <div id="calibCircle" style="display: none;"></div>
@@ -37,8 +38,8 @@
     <!-- fin temporaire gestion cercle -->
 
 	<b>Orientation</b><br>
-              <button id="hips-coronelli" class="pure-button" name="ref-hips" onclick="aladin.setImageSurvey('Coronelli')">Normal</button><br>
-              <button id="hips-illenoroc" class="pure-button" name="ref-hips" onclick="aladin.setImageSurvey('illenoroC')">Inversé</button>
+              <button id="hips-coronelli" class="pure-button" name="ref-hips" onclick="longitudeReversed = false; aladin.reverseLongitude(longitudeReversed)">Normal</button><br>
+              <button id="hips-illenoroc" class="pure-button" name="ref-hips" onclick="longitudeReversed = true; aladin.reverseLongitude(longitudeReversed)">Inversé</button>
 	<br><br>
 
 	<b>Constellations</b>
@@ -232,8 +233,7 @@
     A.init.then(() => {
         var hipsDir="http://alasky.u-strasbg.fr/CDS_P_Coronelli";
         aladin = A.aladin("#aladin-lite-div", {showSimbadPointerControl: true, expandLayersControl: true, realFullscreen: true, fov: 100, allowFullZoomout: true, showReticle: false });
-        aladin.createImageSurvey('illenoroC', 'illenoroC', hipsDir, 'equatorial', 4, {imgFormat: 'jpg', longitudeReversed: false});
-        aladin.createImageSurvey('Coronelli', 'Coronelli', hipsDir, 'equatorial', 4, {imgFormat: 'jpg', longitudeReversed: true});
+        aladin.createImageSurvey('Coronelli', 'Coronelli', hipsDir, 'equatorial', 4, {imgFormat: 'jpg'});
         aladin.setImageSurvey('Coronelli');
 
         $('#layersControlLeft').show();

--- a/examples/al-flip-longitude-axis.html
+++ b/examples/al-flip-longitude-axis.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+</head>
+<body>
+    <div id="aladin-lite-div" style="width: 1024px; height: 768px"></div>
+<script type="module">
+import A from '../src/js/A.js';
+
+A.init.then(() => {
+    let aladin = A.aladin('#aladin-lite-div', {longitudeReversed: true, showCooGrid: true, cooFrame: 'galactic', target: '0 0', fov: 100});
+    //aladin.reverseLongitude(true)
+
+    setTimeout(
+        () => {
+            aladin.reverseLongitude(false)
+        },
+        5000
+    )
+});
+</script>
+</body>
+</html>

--- a/examples/al-fullscreen.html
+++ b/examples/al-fullscreen.html
@@ -5,16 +5,16 @@
 <body>
     <div>
 <div id="offset" style="display: inline-block; width: 200px; height: 100px"></div>
-<div id="aladin-lite-div" style="display: inline-block; width: 50%"></div>
+<div id="aladin-lite-div" style="width: 500px; height: 500px"></div>
 </div>
 <!--<script type="text/javascript" src="https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js" charset="utf-8"></script>-->
 
 
-<script>let aladin, hips</script>
 <script type="module">
     import A from '../src/js/A.js';
+    let aladin;
     A.init.then(() => {
-        aladin = A.aladin('#aladin-lite-div', {projection: 'TAN', cooFrame: 'galactic', showSettingsControl: true, showSimbadPointerControl: true, showContextMenu: true, target: 'galactic center', survey: 'P/Finkbeiner'});
+        aladin = A.aladin('#aladin-lite-div', {projection: 'TAN', cooFrame: 'galactic', showSettingsControl: true, showSimbadPointerControl: true, showContextMenu: true, target: 'galactic center'});
         // possible values are 'blues', 'cividis', 'cubehelix', 'eosb', 'grayscale', 'inferno', 'magma', 'native', 'parula', 'plasma', 'rainbow',
         // 'rdbu', 'rdylbu', 'redtemperature', 'sinebow', 'spectral', 'summer', 'viridis', 'ylgnbu' and 'ylorbr'
 

--- a/examples/al-hips-order-list.html
+++ b/examples/al-hips-order-list.html
@@ -10,7 +10,7 @@
     import A from '../src/js/A.js';
     let aladin;
     A.init.then(() => {
-        aladin = A.aladin('#aladin-lite-div', {survey: 'http://alasky.cds.unistra.fr/ancillary/GaiaDR2/hips-density-map/', showProjectionControl: true, showContextMenu: true, showStatusBar: true, fullScreen: true, target: 'galactic center'});
+        aladin = A.aladin('#aladin-lite-div', {survey: 'http://alasky.cds.unistra.fr/ancillary/GaiaDR2/hips-density-map/', showProjectionControl: true, showContextMenu: true, showStatusBar: true, fullScreen: true, target: 'galactic center', expandLayersControl: true});
 
         const fluxMap = aladin.createImageSurvey('gdr3-color-flux-map', 'Gaia DR3 flux map', 'https://alasky.u-strasbg.fr/ancillary/GaiaEDR3/color-Rp-G-Bp-flux-map', 'equatorial', 7);
         const densityMap = aladin.createImageSurvey('gdr3-density-map', 'Gaia DR3 density map', 'sdfsg', 'equatorial', 7, {formats: ['fits']});

--- a/examples/al-multiple-surveys.html
+++ b/examples/al-multiple-surveys.html
@@ -8,7 +8,7 @@
 <script type="module">
     import A from '../src/js/A.js';
     A.init.then(() => {
-        aladin = A.aladin('#aladin-lite-div', {projection: 'MOL', fullScreen: true, fov: 360, survey: ['P/DM/vizMine', 'P/HST/GOODS/color', 'P/MATLAS/g'], target: '0 0', showProjectionControl: false, showSettingsControl: false, showLayersControl: false, showCooGrid: false, showFrame: false, showCooLocation: false});
+        aladin = A.aladin('#aladin-lite-div', {projection: 'MOL', fullScreen: true, fov: 360, survey: ['P/DM/vizMine', 'P/HST/GOODS/color', 'P/MATLAS/g'], target: '0 0', showProjectionControl: false, showSettingsControl: false, showLayersControl: true, showCooGrid: false, showFrame: false, showCooLocation: false});
     });
 </script>
 

--- a/examples/al-no-properties.html
+++ b/examples/al-no-properties.html
@@ -10,7 +10,6 @@ A.init.then(() => {
     let aladin = A.aladin('#aladin-lite-div', {fov: 70,projection: "AIT"});
     
     aladin.setOverlayImageLayer(A.imageHiPS(
-        'Fermi',
         "https://alasky.cds.unistra.fr/Fermi/Color",
         {
             name: "Fermi color",

--- a/examples/al-save-colormap.html
+++ b/examples/al-save-colormap.html
@@ -15,16 +15,17 @@
         let survey1 = aladin.getBaseImageLayer();
         survey1.setColormap('magma', {stretch: 'linear'});
 
-        let survey2 = aladin.newImageSurvey("CSIRO/P/RACS/low/I");
-        aladin.setImageLayer(survey2)
+        let survey2 = aladin.newImageSurvey("CSIRO/P/RACS/low/I", {name: 'racs low'});
         survey2.setColormap('rdbu', {stretch: 'linear'});
+
+        aladin.setImageLayer(survey2)
+
 
         let survey3 = aladin.newImageSurvey("CSIRO/P/RACS/mid/I");
         aladin.setImageLayer(survey3)
         survey3.setColormap('cubehelix', {stretch: 'asinh'});
 
         aladin.setImageLayer(survey2);
-
         setTimeout(() => {
             aladin.removeHiPSFromFavorites(survey3)
         }, 5000);

--- a/examples/al-set-colormap.html
+++ b/examples/al-set-colormap.html
@@ -5,7 +5,6 @@
 <body>
 <div id="aladin-lite-div" style="width: 1024px; height: 768px"></div>
 
-<div id='aladin-statsDiv'></div>
 <script>let aladin, hips</script>
 <script type="module">
     import A from '../src/js/A.js';

--- a/src/core/al-api/src/hips.rs
+++ b/src/core/al-api/src/hips.rs
@@ -223,14 +223,8 @@ pub struct ImageMetadata {
     pub blend_cfg: BlendCfg,
     #[serde(default = "default_opacity")]
     pub opacity: f32,
-    #[serde(default = "default_longitude_reversed")]
-    pub longitude_reversed: bool,
     /// the current format chosen
     pub img_format: ImageExt,
-}
-
-fn default_longitude_reversed() -> bool {
-    true
 }
 
 fn default_opacity() -> f32 {

--- a/src/core/src/app.rs
+++ b/src/core/src/app.rs
@@ -1323,6 +1323,10 @@ impl App {
         self.camera.get_longitude_reversed()
     }
 
+    pub(crate) fn set_longitude_reversed(&mut self, longitude_reversed: bool) {
+        self.camera.set_longitude_reversed(longitude_reversed, &self.projection);
+    }
+
     pub(crate) fn add_catalog(&mut self, _name: String, table: JsValue, _colormap: String) {
         //let mut exec_ref = self.exec.borrow_mut();
         let _table = table;

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -566,6 +566,12 @@ impl WebClient {
         self.app.get_longitude_reversed()
     }
 
+    /// Set the longitude axis reversed globally
+    #[wasm_bindgen(js_name = setLongitudeReversed)]
+    pub fn set_longitude_reversed(&mut self, longitude_reversed: bool) {
+        self.app.set_longitude_reversed(longitude_reversed);
+    }
+
     /// Get the field of view angle value when the view is zoomed out to its maximum
     ///
     /// This method is dependent of the projection currently set.

--- a/src/core/src/renderable/mod.rs
+++ b/src/core/src/renderable/mod.rs
@@ -308,12 +308,6 @@ impl Layers {
             .ok_or(err_layer_not_found)?;
         self.layers.remove(id_layer);
 
-        // Loop over all the meta for its longitude reversed property
-        // and set the camera to it if there is at least one
-        let longitude_reversed = self.meta.values().any(|meta| meta.longitude_reversed);
-
-        camera.set_longitude_reversed(longitude_reversed, proj);
-
         // Check if the url is still used
         let id_still_used = self.ids.values().any(|rem_id| rem_id == &id);
         if id_still_used {
@@ -421,11 +415,6 @@ impl Layers {
 
         // 2. Add the meta information of the layer
         self.meta.insert(layer.clone(), meta);
-        // Loop over all the meta for its longitude reversed property
-        // and set the camera to it if there is at least one
-        let longitude_reversed = self.meta.values().any(|meta| meta.longitude_reversed);
-
-        camera.set_longitude_reversed(longitude_reversed, proj);
 
         // 3. Add the image hips
         let creator_did = String::from(properties.get_creator_did());
@@ -500,11 +489,6 @@ impl Layers {
 
         // 2. Add the meta information of the layer
         self.meta.insert(layer.clone(), meta);
-        // Loop over all the meta for its longitude reversed property
-        // and set the camera to it if there is at least one
-        let longitude_reversed = self.meta.values().any(|meta| meta.longitude_reversed);
-
-        camera.set_longitude_reversed(longitude_reversed, proj);
 
         // 3. Add the fits image
         // The layer does not already exist

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -143,7 +143,8 @@ import { Polyline } from "./shapes/Polyline";
  * @property {number} [gridOptions.labelSize=15] - The font size of the labels.
  * 
  * @property {string} [projection="SIN"] - Projection type. Can be 'SIN' for orthographic, 'MOL' for mollweide, 'AIT' for hammer-aitoff, 'ZEA' for zenital equal-area or 'MER' for mercator
- * @property {boolean} [log=true] - Whether to log events.
+ * @property {boolean} [longitudeReversed=false] - Longitude reverse axis flag. Set to true to reverse the longitude axis. This is especially needed for planetary survey visualization. Default is set to false.
+* @property {boolean} [log=true] - Whether to log events.
  * @property {boolean} [samp=false] - Whether to enable SAMP (Simple Application Messaging Protocol).
  * @property {boolean} [realFullscreen=false] - Whether to use real fullscreen mode.
  * @property {boolean} [pixelateCanvas=true] - Whether to pixelate the canvas.
@@ -518,6 +519,10 @@ export let Aladin = (function () {
         if (options.northPoleOrientation) {
             this.setRotation(options.northPoleOrientation);
         }
+
+        if (options.longitudeReversed !== undefined && options.longitudeReversed !== null) {
+            this.reverseLongitude(options.longitudeReversed)
+        }
     };
 
     Aladin.prototype._setupUI = function (options) {
@@ -700,6 +705,8 @@ export let Aladin = (function () {
         projection: "SIN",
         log: true,
         samp: false,
+        // Longitude reversed flag
+        longitudeReversed: false,
         realFullscreen: false,
         pixelateCanvas: true,
         manualSelection: false
@@ -898,7 +905,7 @@ export let Aladin = (function () {
      * Sets the coordinate frame of the Aladin instance to the specified frame.
      *
      * @memberof Aladin
-     * @param {string} frame - The name of the coordinate frame. Possible values: 'j2000d', 'j2000', 'gal', 'icrs'. The given string is case insensitive.
+     * @param {string} frame - The name of the coordinate frame. Possible values: 'j2000d', 'j2000', 'gal', 'icrs', 'equatorial'. The given string is case insensitive.
      *
      * @example
      * // Set the coordinate frame to 'J2000'
@@ -1786,6 +1793,16 @@ export let Aladin = (function () {
     };
 
     /**
+     * Reverse the longitude axis of the view globally
+     *
+     * @memberof Aladin
+     * @param {Boolean} [longitudeReversed] - Reverse the longitude axis
+     */
+    Aladin.prototype.reverseLongitude = function (longitudeReversed) {
+        this.view.reverseLongitude(longitudeReversed)
+    };
+
+    /**
      * Add a new HiPS layer to the view on top of the others
      *
      * @memberof Aladin
@@ -1959,16 +1976,14 @@ export let Aladin = (function () {
                 if (!cachedLayerOptions) {
                     hipsCache.append(imageLayer.id, imageLayer.options)
                 } else {
-                    // Set the options from what is in the cache
-                    imageLayer.setOptions(cachedLayerOptions);
+                    // Set the image layer object with the options from the cache.
+                    imageLayer.setOptions(cachedLayerOptions)
                 }
             }
         }
 
         // Add it to the hipsList if it is not there yet
         this.addHiPSToFavorites(imageLayer)
-
-        imageLayer.layer = layer;
 
         return this.view.setOverlayImageLayer(imageLayer, layer);
     };
@@ -2186,7 +2201,7 @@ export let Aladin = (function () {
         aladin.on("layerChanged", (layer, layerName, state) => {
             console.log("layerChanged", layer, layerName, state)
         })
-     */
+    */
     Aladin.prototype.on = function (what, myFunction) {
         if (Aladin.AVAILABLE_CALLBACKS.indexOf(what) < 0) {
             return;

--- a/src/js/ColorCfg.js
+++ b/src/js/ColorCfg.js
@@ -41,17 +41,31 @@
         this.stretch = (options && options.stretch) || "linear";
         this.stretch = this.stretch.toLowerCase();
         this.reversed = false;
+        // Keep the image tile format because we want the cuts
+        this.imgFormat = options.imgFormat || 'png';
 
         if (options && options.reversed === true) {
             this.reversed = true;
         }
 
+        this.minCut = {
+            webp: 0.0,
+            jpeg: 0.0,
+            png: 0.0,
+            fits: undefined // wait the default value coming from the properties
+        };
         if (options && Number.isFinite(options.minCut)) {
-            this.minCut = options.minCut;
+            this.minCut[this.imgFormat] = options.minCut;
         }
 
+        this.maxCut = {
+            webp: 1.0,
+            jpeg: 1.0,
+            png: 1.0,
+            fits: undefined // wait the default value coming from the properties
+        };
         if (options && Number.isFinite(options.maxCut)) {
-            this.maxCut = options.maxCut;
+            this.maxCut[this.imgFormat] = options.maxCut;
         }
 
         this.additiveBlending = options && options.additive;
@@ -93,8 +107,8 @@
                 kContrast: this.kContrast,
 
                 stretch: this.stretch,
-                minCut: this.minCut,
-                maxCut: this.maxCut,
+                minCut: this.minCut[this.imgFormat],
+                maxCut: this.maxCut[this.imgFormat],
                 reversed: this.reversed,
                 cmapName: this.colormap,
             }
@@ -102,6 +116,9 @@
     }
     
     ColorCfg.prototype.setOptions = function(options) {
+        // Update the imgFormat 
+        this.imgFormat = options.imgFormat || this.imgFormat;
+
         this.setColormap(options.colormap, options)
 
         this.setCuts(options.minCut, options.maxCut)
@@ -231,18 +248,28 @@
         return this.reversed;
     };
 
-    // @api
+    // Sets the cuts for the current image format
     ColorCfg.prototype.setCuts = function(minCut, maxCut) {
-        if (minCut === null || minCut === undefined || maxCut === null || maxCut === undefined) {
-            return;
+        if (minCut instanceof Object) {
+            // Mincut is given in the form of an javascript object with all the formats
+            this.minCut = minCut
+        } else if (minCut !== null && minCut !== undefined) {
+            this.minCut[this.imgFormat] = minCut;
         }
 
-        this.minCut = minCut;
-        this.maxCut = maxCut;
+        if (maxCut instanceof Object) {
+            this.maxCut = maxCut;
+        } else if (maxCut !== null && maxCut !== undefined) {
+            this.maxCut[this.imgFormat] = maxCut;
+        }
     };
 
+    // Returns the cuts for the current image format
     ColorCfg.prototype.getCuts = function() {
-        return [this.minCut, this.maxCut];
+        return [
+            this.minCut[this.imgFormat],
+            this.maxCut[this.imgFormat]
+        ];
     };
 
     return ColorCfg;

--- a/src/js/CooFrameEnum.js
+++ b/src/js/CooFrameEnum.js
@@ -49,7 +49,7 @@ export let CooFrameEnum = (function() {
             if (str.indexOf('j2000d')==0 || str.indexOf('icrsd')==0) {
                 return CooFrameEnum.ICRSd;
             }
-            else if (str.indexOf('j2000')==0 || str.indexOf('icrs')==0) {
+            else if (str.indexOf('j2000')==0 || str.indexOf('icrs')==0 || str.indexOf('equatorial')==0) {
                 return CooFrameEnum.ICRS;
             }
             else if (str.indexOf('gal')==0) {

--- a/src/js/Image.js
+++ b/src/js/Image.js
@@ -136,12 +136,11 @@ export let Image = (function () {
         this.id = url;
         this.name = (options && options.name) || this.url;
         this.imgFormat = options && options.imgFormat;
-        //this.formats = [this.imgFormat];
+        this.acceptedFormats = [this.imgFormat];
+
         // callbacks
         this.successCallback = options && options.successCallback;
         this.errorCallback = options && options.errorCallback;
-
-        this.longitudeReversed = false;
 
         this.colorCfg = new ColorCfg(options);
         this.options = options || {};
@@ -329,11 +328,18 @@ export let Image = (function () {
          */
         Image.prototype.readPixel = HiPS.prototype.readPixel;
 
-       
-        /** PRIVATE METHODS **/
+        /**
+         * Get the list of accepted tile format for that HiPS
+         *
+         * @memberof Image
+         *
+         * @returns {string[]} Returns the formats accepted for the survey, i.e. the formats of tiles that are availables. Could be PNG, WEBP, JPG and FITS.
+         */
+        Image.prototype.getAvailableFormats = HiPS.prototype.getAvailableFormats;
+
+
         Image.prototype._setView = function (view) {
             this.view = view;
-            this._saveInCache();
         };
 
         // FITS images does not mean to be used for storing planetary data
@@ -356,7 +362,7 @@ export let Image = (function () {
         // Private method for updating the view with the new meta
         Image.prototype._updateMetadata = HiPS.prototype._updateMetadata;
 
-        Image.prototype._add = function (layer) {
+        Image.prototype._add2View = function (layer) {
             this.layer = layer;
 
             let self = this;
@@ -388,11 +394,10 @@ export let Image = (function () {
             }
 
             promise = promise.then((imageParams) => {
-                self.formats = [self.imgFormat];
+                self.acceptedFormats = [self.imgFormat];
 
                 // There is at least one entry in imageParams
                 self.added = true;
-                self._setView(self.view);
 
                 // Set the automatic computed cuts
                 let [minCut, maxCut] = self.getCuts();
@@ -442,7 +447,6 @@ export let Image = (function () {
                         stream,
                         {
                             ...self.colorCfg.get(),
-                            longitudeReversed: this.longitudeReversed,
                             imgFormat: 'fits',
                         },
                         layer
@@ -460,7 +464,6 @@ export let Image = (function () {
                                 stream,
                                 {
                                     ...self.colorCfg.get(),
-                                    longitudeReversed: this.longitudeReversed,
                                     imgFormat: 'fits',
                                 },
                                 layer
@@ -470,7 +473,8 @@ export let Image = (function () {
                 }
             })
             .then((imageParams) => {
-                self.imgFormat = 'fits';
+                self.imgFormat = 'fits'
+                self.colorCfg.setOptions({imgFormat: 'fits'});
 
                 return Promise.resolve(imageParams);
             })
@@ -562,14 +566,14 @@ export let Image = (function () {
                         wcs,
                         {
                             ...self.colorCfg.get(),
-                            longitudeReversed: this.longitudeReversed,
                             imgFormat: 'jpeg',
                         },
                         layer
                     )
             })
             .then((imageParams) => {
-                self.imgFormat = 'jpeg';
+                self.imgFormat = 'jpeg'
+                self.colorCfg.setOptions({imgFormat: 'jpeg'});
                 return Promise.resolve(imageParams);
             })
             .finally(() => {

--- a/src/js/gui/Box/HiPSSettingsBox.js
+++ b/src/js/gui/Box/HiPSSettingsBox.js
@@ -310,7 +310,8 @@ import { Form } from "../Widgets/Form.js";
         let fmtInput = this.pixelSettingsContent.getInput('fmt')
 
         fmtInput.innerHTML = '';
-        for (const option of layer.formats) {
+
+        for (const option of layer.getAvailableFormats()) {
             fmtInput.innerHTML += "<option>" + option + "</option>";
         }
         fmtInput.value = layer.imgFormat;

--- a/src/js/gui/Box/StackBox.js
+++ b/src/js/gui/Box/StackBox.js
@@ -85,7 +85,7 @@ export class OverlayStackBox extends Box {
                 hoverColor: 'red',
                 onClick: "showTable",
                 shape: (s) => {
-                    let galaxy = ["Seyfert","Seyfert_1", "Seyfert_2","LSB_G","PartofG","RadioG","Gin","GinPair","HII_G","LensedG","BClG","BlueCompG","EmG","GinCl","GinGroup","StarburstG","LINER","AGN","Galaxy"].some((n) => s.data.main_type.indexOf(n) >= 0);
+                    let galaxy = ["Seyfert","Seyfert_1", "Seyfert_2","LSB_G","PartofG","RadioG","Gin","GinPair","HII_G","LensedG","BClG","BlueCompG","EmG","GinCl","GinGroup","StarburstG","LINER","AGN", "Galaxy", "GtowardsGroup", "GtowardsCl", "BrightestCG"].some((n) => s.data.main_type.indexOf(n) >= 0);
                     if (!galaxy) return;
 
                     let a = +s.data.size_maj;
@@ -710,6 +710,7 @@ export class OverlayStackBox extends Box {
         // Add a listener for HiPS list changes
         ALEvent.FAVORITE_HIPS_LIST_UPDATED.listenedBy(document.body, (event) => {
             let favoritesHips = event.detail;
+
             self.cachedHiPS = {};
 
             for (var hips of favoritesHips) {


### PR DESCRIPTION
Adds a method on the Aladin object to flip the longitude axis globally

Example:
```js
let aladin = A.aladin('#aladin-lite-div');
aladin.reverseLongitude(true)
```

This targets issue #212 