### PR TITLE
bug: jpeg draw black screen when tiles are missing

### DIFF
--- a/src/core/src/renderable/hips/d2/buffer.rs
+++ b/src/core/src/renderable/hips/d2/buffer.rs
@@ -196,7 +196,7 @@ impl HiPS2DBuffer {
             let mutex_locked = image.borrow();
             let images = mutex_locked.as_ref().unwrap_abort();
             for (idx, image) in images.iter().enumerate() {
-                self.push(&HEALPixCell(depth_tile, idx as u64), image, time_req)?;
+                self.push(&HEALPixCell(depth_tile, idx as u64), Some(image), time_req)?;
             }
         }
 
@@ -272,7 +272,7 @@ impl HiPS2DBuffer {
     pub fn push<I: Image>(
         &mut self,
         cell: &HEALPixCell,
-        image: I,
+        image: Option<I>,
         time_request: Time,
     ) -> Result<(), JsValue> {
         if !self.contains_tile(cell) {
@@ -331,14 +331,16 @@ impl HiPS2DBuffer {
                 &mut self.base_textures[idx as usize]
             };
 
-            send_to_gpu(
-                cell,
-                texture,
-                image,
-                &self.texture_2d_array,
-                &mut self.config,
-            )?;
-
+            if let Some(image) = image {
+                send_to_gpu(
+                    cell,
+                    texture,
+                    image,
+                    &self.texture_2d_array,
+                    &mut self.config,
+                )?;
+            }
+            
             texture.append(
                 cell, // The tile cell
                 &self.config,

--- a/src/core/src/renderable/hips/d2/texture.rs
+++ b/src/core/src/renderable/hips/d2/texture.rs
@@ -182,6 +182,7 @@ impl<'a> HpxTexture2DUniforms<'a> {
 
 use al_core::shader::{SendUniforms, ShaderBound};
 impl<'a> SendUniforms for HpxTexture2DUniforms<'a> {
+    // Info: These uniforms are used for raytracing drawing mode only
     fn attach_uniforms<'b>(&self, shader: &'b ShaderBound<'b>) -> &'b ShaderBound<'b> {
         shader
             .attach_uniform(&format!("{}{}", self.name, "uniq"), &self.texture.uniq)
@@ -191,8 +192,12 @@ impl<'a> SendUniforms for HpxTexture2DUniforms<'a> {
             )
             .attach_uniform(
                 &format!("{}{}", self.name, "empty"),
-                //&((self.texture.full as u8) as f32),
-                &0.0,
+                // This is useful for FITS tiles only because:
+                // - for JPEG, missing tiles are inserted in the buffer and black is drawn
+                // - for PNG, tiles are not inserted but default color chosen is fully transparent (might be vec4(0.0, 0.0, 0.0, 0.0))
+                // 
+                // Therefore for FITS files we must indicate GPU which base tiles are missing so that we draw fully transparent pixels
+                &((!self.texture.full as u8) as f32),
             )
             .attach_uniform(
                 &format!("{}{}", self.name, "start_time"),

--- a/src/glsl/webgl2/hips/raytracer/grayscale_to_colormap_i.frag
+++ b/src/glsl/webgl2/hips/raytracer/grayscale_to_colormap_i.frag
@@ -26,7 +26,7 @@ uniform float opacity;
 #include ../../projection/hpx_proj.glsl;
 
 vec4 get_tile_color(vec3 pos) {
-HashDxDy result = hash_with_dxdy(0, pos.zxy);
+    HashDxDy result = hash_with_dxdy(0, pos.zxy);
 
     int idx = result.idx;
     vec2 uv = vec2(result.dy, result.dx);


### PR DESCRIPTION
This fixes #244 but also adds another fix I discovered for FITS tiles drawn in raytracing mode (i.e. very large allsky fovs, when only base HEALPix 0 order tiles are drawn). As FITS tiles are only 1 channel, they do not contain any transparency channel so when sending the base tiles to the GPU I indicate which is missing so that I can render them fully transparent instead of the previous black color.