### PR TITLE
feat: zoom screen factor setting

### DIFF
--- a/examples/al-init-custom-options.html
+++ b/examples/al-init-custom-options.html
@@ -31,15 +31,6 @@
                 samp: true,
             }
         );
-
-        /*let id;
-        aladin.on("zoomChanged", () => {
-            if (id)
-                clearTimeout(id);
-            id = setTimeout(() => {
-                console.log("wheel stopped, new cone search here")
-            }, 500);
-        })*/
     });
 </script>
 </body>

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -88,4 +88,4 @@ codegen-units = 16
 rpath = false
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = true
+wasm-opt = false

--- a/src/core/src/app.rs
+++ b/src/core/src/app.rs
@@ -1353,11 +1353,12 @@ impl App {
     pub(crate) fn resize(&mut self, width: f32, height: f32) {
         self.camera.set_screen_size(width, height, &self.projection);
         self.camera
-            .set_aperture(self.camera.get_aperture(), &self.projection);
+            .set_zoom_factor(self.camera.get_zoom_factor(), &self.projection);
+
         // resize the view fbo
-        let screen_size = self.camera.get_screen_size();
-        self._fbo_view
-            .resize(screen_size.x as usize, screen_size.y as usize);
+        //let screen_size = self.camera.get_screen_size();
+        //self._fbo_view
+        //    .resize(screen_size.x as usize, screen_size.y as usize);
         // resize the ui fbo
         //self.fbo_ui.resize(w as usize, h as usize);
 
@@ -1561,7 +1562,7 @@ impl App {
         self.camera.get_center_pos_angle()
     }
 
-    pub(crate) fn set_fov(&mut self, fov: Angle<f64>) {
+    pub(crate) fn set_fov(&mut self, fov: f64) {
         // For the moment, no animation is triggered.
         // The fov is directly set
         self.camera.set_aperture(fov, &self.projection);
@@ -1569,16 +1570,19 @@ impl App {
         self.request_redraw = true;
     }
 
+    pub(crate) fn set_fov_range(&mut self, min_fov: Option<f64>, max_fov: Option<f64>) {
+        self.camera.set_fov_range(
+            min_fov.map(|v| v.to_radians()),
+            max_fov.map(|v| v.to_radians()),
+            &self.projection,
+        );
+        self.request_for_new_tiles = true;
+        self.request_redraw = true;
+    }
+
     pub(crate) fn set_inertia(&mut self, inertia: bool) {
         *self.disable_inertia.borrow_mut() = !inertia;
     }
-
-    /*pub(crate) fn project_line(&self, lon1: f64, lat1: f64, lon2: f64, lat2: f64) -> Vec<Vector2<f64>> {
-        let v1: Vector3<f64> = LonLatT::new(ArcDeg(lon1).into(), ArcDeg(lat1).into()).vector();
-        let v2: Vector3<f64> = LonLatT::new(ArcDeg(lon2).into(), ArcDeg(lat2).into()).vector();
-
-        line::project_along_great_circles(&v1, &v2, &self.camera, self.projection)
-    }*/
 
     pub(crate) fn go_from_to(&mut self, s1x: f64, s1y: f64, s2x: f64, s2y: f64) {
         // Select the HiPS layer rendered lastly
@@ -1624,13 +1628,19 @@ impl App {
         self.camera.get_texture_depth() as i32
     }
 
-    pub(crate) fn get_clip_zoom_factor(&self) -> f64 {
-        self.camera.get_clip_zoom_factor()
+    pub(crate) fn get_zoom_factor(&self) -> f64 {
+        self.camera.get_zoom_factor()
+    }
+
+    pub(crate) fn set_zoom_factor(&mut self, zoom_factor: f64) {
+        self.camera.set_zoom_factor(zoom_factor, &self.projection);
+
+        self.request_for_new_tiles = true;
+        self.request_redraw = true;
     }
 
     pub(crate) fn get_fov(&self) -> f64 {
-        let deg: ArcDeg<f64> = self.camera.get_aperture().into();
-        deg.0
+        self.camera.get_aperture().to_degrees()
     }
 
     pub(crate) fn get_colormaps(&self) -> &Colormaps {

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -469,6 +469,12 @@ impl WebClient {
         Ok(fov)
     }
 
+    /// Get the max aperture of a projection (in degrees)
+    #[wasm_bindgen(js_name = atZoomBoundaries)]
+    pub fn get_max_aperture(&self) -> bool {
+        self.app.camera.at_zoom_boundaries(&self.app.projection)
+    }
+
     /// Set the field of view
     ///
     /// # Arguments
@@ -476,18 +482,51 @@ impl WebClient {
     /// * `fov` - The field of view in degrees
     #[wasm_bindgen(js_name = setFieldOfView)]
     pub fn set_fov(&mut self, fov: f64) -> Result<(), JsValue> {
-        let fov = ArcDeg(fov).into();
-
-        self.app.set_fov(fov);
+        self.app.set_fov(fov.to_radians());
 
         Ok(())
     }
 
+    /// Enable/Disable inertia effect after panning and releasing the mouse
     #[wasm_bindgen(js_name = setInertia)]
     pub fn set_inertia(&mut self, inertia: bool) -> Result<(), JsValue> {
         self.app.set_inertia(inertia);
 
         Ok(())
+    }
+
+    /// Set a range of FoVs that contrains the zooming in that range
+    ///
+    /// # Arguments
+    ///
+    /// * `min_fov` - The minimum field of view value in degrees
+    /// * `max_fov` - The maximum field of view value in degrees
+    #[wasm_bindgen(js_name = setFoVRange)]
+    pub fn set_fov_range(
+        &mut self,
+        min_fov: Option<f64>,
+        max_fov: Option<f64>,
+    ) -> Result<(), JsValue> {
+        self.app.set_fov_range(min_fov, max_fov);
+
+        Ok(())
+    }
+
+    /// Get the FoV range in degrees
+    #[wasm_bindgen(js_name = getFoVRange)]
+    pub fn get_fov_range(&self) -> Box<[f64]> {
+        Box::new([
+            self.app
+                .camera
+                .min_fov
+                .map(|v| v.to_degrees())
+                .unwrap_or(-1.0),
+            self.app
+                .camera
+                .max_fov
+                .map(|v| v.to_degrees())
+                .unwrap_or(-1.0),
+        ])
     }
 
     /// Set the absolute orientation of the view
@@ -537,14 +576,20 @@ impl WebClient {
         self.app.get_max_fov().to_degrees()
     }
 
-    /// Get the clip zoom factor of the view
+    /// Get the zoom factor of the view
     ///
     /// This factor is deduced from the field of view angle.
     /// It is a constant which when multiplied to the screen coordinates
     /// gives the coordinates in clipping space.
-    #[wasm_bindgen(js_name = getClipZoomFactor)]
-    pub fn get_clip_zoom_factor(&self) -> Result<f64, JsValue> {
-        Ok(self.app.get_clip_zoom_factor())
+    #[wasm_bindgen(js_name = getZoomFactor)]
+    pub fn get_zoom_factor(&self) -> Result<f64, JsValue> {
+        Ok(self.app.get_zoom_factor())
+    }
+
+    /// Set the zoom factor of the view
+    #[wasm_bindgen(js_name = setZoomFactor)]
+    pub fn set_zoom_factor(&mut self, zoom_factor: f64) -> Result<(), JsValue> {
+        Ok(self.app.set_zoom_factor(zoom_factor))
     }
 
     /// Set the center of the view in ICRS coosys

--- a/src/core/src/math/projection/mod.rs
+++ b/src/core/src/math/projection/mod.rs
@@ -21,8 +21,8 @@ pub mod domain;
 
 use crate::math::angle::ToAngle;
 
-use domain::{basic, full::FullScreen};
 use crate::math::angle::Angle;
+use domain::{basic, full::FullScreen};
 /* S <-> NDC space conversion methods */
 pub fn screen_to_ndc_space(
     pos_screen_space: &XYScreen<f64>,
@@ -61,7 +61,7 @@ pub fn ndc_to_screen_space(
 /* NDC <-> CLIP space conversion methods */
 pub fn clip_to_ndc_space(pos_clip_space: &XYClip<f64>, camera: &CameraViewPort) -> XYNDC<f64> {
     let ndc_to_clip = camera.get_ndc_to_clip();
-    let clip_zoom_factor = camera.get_clip_zoom_factor();
+    let clip_zoom_factor = camera.get_zoom_factor();
 
     Vector2::new(
         pos_clip_space.x / (ndc_to_clip.x * clip_zoom_factor),
@@ -74,7 +74,7 @@ pub fn ndc_to_clip_space(
     camera: &CameraViewPort,
 ) -> XYClip<f64> {
     let ndc_to_clip = camera.get_ndc_to_clip();
-    let clip_zoom_factor = camera.get_clip_zoom_factor();
+    let clip_zoom_factor = camera.get_zoom_factor();
 
     Vector2::new(
         pos_normalized_device.x * ndc_to_clip.x * clip_zoom_factor,
@@ -297,25 +297,16 @@ impl ProjectionType {
             .map(|pos_normalized_device| ndc_to_screen_space(&pos_normalized_device, camera))
     }
 
-    /*pub(crate) fn is_allsky(&self) -> bool {
-        match self {
-            ProjectionType::Sin(_) | ProjectionType::Tan(_) => false,
-            //| ProjectionType::Feye(_)
-            //| ProjectionType::Ncp(_) => false,
-            _ => true,
-        }
-    }*/
-
     pub const fn bounds_size_ratio(&self) -> f64 {
         match self {
             // Zenithal projections
             /* TAN,      Gnomonic projection        */
             ProjectionType::Tan(_) => 1.0,
-            /* STG,	     Stereographic projection   */
+            /* STG,         Stereographic projection   */
             ProjectionType::Stg(_) => 1.0,
-            /* SIN,	     Orthographic		        */
+            /* SIN,         Orthographic                       */
             ProjectionType::Sin(_) => 1.0,
-            /* ZEA,	     Equal-area 		        */
+            /* ZEA,         Equal-area                         */
             ProjectionType::Zea(_) => 1.0,
             /* FEYE,     Fish-eyes                  */
             //ProjectionType::Feye(_) => 1.0,
@@ -327,7 +318,6 @@ impl ProjectionType {
             //ProjectionType::Arc(_) => 1.0,
             /* NCP,                                 */
             //ProjectionType::Ncp(_) => 1.0,
-
             // Pseudo-cylindrical projections
             /* AIT,      Aitoff                     */
             ProjectionType::Ait(_) => 2.0,
@@ -337,7 +327,6 @@ impl ProjectionType {
             //ProjectionType::Par(_) => 2.0,
             // SFL,                                 */
             //ProjectionType::Sfl(_) => 2.0,
-
             // Cylindrical projections
             // MER,      Mercator                   */
             ProjectionType::Mer(_) => 1.0,
@@ -347,11 +336,9 @@ impl ProjectionType {
             //ProjectionType::Cea(_) => 1.0,
             // CYP,                                 */
             //ProjectionType::Cyp(_) => 1.0,
-
             // Conic projections
             // COD,                                 */
             //ProjectionType::Cod(_) => 1.0,
-
             // HEALPix hybrid projection
             //ProjectionType::Hpx(_) => 2.0,
         }
@@ -367,7 +354,7 @@ impl ProjectionType {
             /* SIN,	     Orthographic		        */
             ProjectionType::Sin(_) => 180.0_f64.to_radians().to_angle(),
             /* ZEA,	     Equal-area 		        */
-            ProjectionType::Zea(_) => 360.0_f64.to_radians().to_angle(),
+            ProjectionType::Zea(_) => 359.9_f64.to_radians().to_angle(),
             /* FEYE,     Fish-eyes                  */
             //ProjectionType::Feye(_) => 190.0,
             /* AIR,                                 */
@@ -408,7 +395,7 @@ impl ProjectionType {
         }
     }
 
-    pub fn get_area(&self) -> &ProjDefType {
+    pub const fn get_area(&self) -> &ProjDefType {
         match self {
             // Zenithal projections
             /* TAN,      Gnomonic projection        */

--- a/src/core/src/renderable/catalog/manager.rs
+++ b/src/core/src/renderable/catalog/manager.rs
@@ -232,7 +232,6 @@ impl Manager {
         // Cells that are of depth > 7 are not handled by the hashmap (limited to depth 7)
         // For these cells, we draw all the sources lying in the ancestor cell of depth 7 containing
         // this cell
-        //if camera.get_aperture() > P::RASTER_THRESHOLD_ANGLE {
         if camera.get_field_of_view().is_allsky() {
             let cells = crate::healpix::cell::ALLSKY_HPX_CELLS_D0;
 
@@ -414,7 +413,7 @@ impl Catalog {
     }
 
     // Cells are of depth <= 7
-    fn update(&mut self, cells: &[HEALPixCell]) {
+    pub fn update(&mut self, cells: &[HEALPixCell]) {
         let num_sources_in_fov = self.get_total_num_sources_in_fov(cells) as f32;
         // reset the sources in the frame
         let mut sources: Vec<_> = vec![];

--- a/src/core/src/renderable/line/great_circle_arc.rs
+++ b/src/core/src/renderable/line/great_circle_arc.rs
@@ -63,7 +63,7 @@ fn sub_valid_domain(
     projection: &ProjectionType,
     camera: &CameraViewPort,
 ) -> (XYZModel<f64>, XYZModel<f64>) {
-    let d_alpha = camera.get_aperture().to_radians() * 0.02;
+    let d_alpha = camera.get_aperture() * 0.02;
 
     let mut vv = valid_v;
     let mut vi = invalid_v;

--- a/src/core/src/renderable/line/parallel_arc.rs
+++ b/src/core/src/renderable/line/parallel_arc.rs
@@ -60,7 +60,7 @@ pub fn project(lat: f64, mut lon1: f64, lon2: f64, camera: &CameraViewPort, proj
 // * valid_lon and invalid_lon are well defined, i.e. they can be between [-PI; PI] or [0, 2PI] depending
 //   whether they cross or not the zero meridian
 fn sub_valid_domain(lat: f64, valid_lon: f64, invalid_lon: f64, projection: &ProjectionType, camera: &CameraViewPort) -> (f64, f64) {
-    let d_alpha = camera.get_aperture().to_radians() * 0.02;
+    let d_alpha = camera.get_aperture() * 0.02;
 
     let mut l_valid = valid_lon;
     let mut l_invalid = invalid_lon;

--- a/src/core/src/renderable/moc/hierarchy.rs
+++ b/src/core/src/renderable/moc/hierarchy.rs
@@ -56,7 +56,7 @@ impl MOCHierarchy {
         let mut d = self.full_res_depth as usize;
 
         let hpx_cell_size_rad =
-            (smallest_cell_size_px / w_screen_px) * camera.get_aperture().to_radians();
+            (smallest_cell_size_px / w_screen_px) * camera.get_aperture();
 
         while d > 0 {
             //self.mocs[d].cell_indices_in_view(camera);

--- a/src/core/src/renderable/mod.rs
+++ b/src/core/src/renderable/mod.rs
@@ -14,8 +14,6 @@ use crate::tile_fetcher::TileFetcherQueue;
 
 use al_core::image::format::ChannelType;
 
-pub use catalog::Manager;
-
 use al_api::color::ColorRGB;
 use al_api::hips::HiPSCfg;
 use al_api::hips::ImageMetadata;

--- a/src/js/MOC.js
+++ b/src/js/MOC.js
@@ -37,6 +37,13 @@ export let MOC = (function() {
      * @class
      * @constructs MOC
      * @param {MOCOptions} options - Configuration options for the MOC
+     * @property {boolean} perimeter - Show perimeter
+     * @property {boolean} edge - Show the edges of HEALPix cells composing the MOC
+     * @property {boolean} fill - Fill the MOC
+     * @property {number} lineWidth - The width of lines used to draw the MOC
+     * @property {number} opacity - Opacity of the edges, cells, etc... of a MOC
+     * @property {string} color - Color of the edges/perimeter
+     * @property {string} fillColor - Color to fill the MOC with
      */
     let MOC = function(options) {
         //this.order = undefined;

--- a/src/js/ProjectionEnum.js
+++ b/src/js/ProjectionEnum.js
@@ -29,26 +29,26 @@
  *****************************************************************************/
 export let ProjectionEnum = {
    // Zenithal
-   TAN: {id: 1, fov: 150, label: "Tangential"},	         /* Gnomonic projection      */
-   STG: {id: 2, fov: 240, label: "Stereographic"},	      /* Stereographic projection */
-   SIN: {id: 3, fov: 1000, label: "Spheric"},	      /* Orthographic		         */
+   TAN: {id: 1, label: "Tangential"},	         /* Gnomonic projection      */
+   STG: {id: 2, label: "Stereographic"},	      /* Stereographic projection */
+   SIN: {id: 3, label: "Spheric"},	      /* Orthographic		         */
    // TODO: fix why the projection disappears at fov = 360.0
-   ZEA: {id: 4, fov: 1000, label: "Zenital equal-area"},	/* Equal-area 		         */
+   ZEA: {id: 4, label: "Zenital equal-area"},	/* Equal-area 		         */
    //FEYE: {id: 5, fov: 190, label: "fish eye"},
    //AIR: {id: 6, fov: 360, label: "airy"},
    //AZP: {fov: 180},
    //ARC: {id: 7, fov: 360, label: "zenital equidistant"},
    //NCP: {id: 8, fov: 180, label: "north celestial pole"},
    // Cylindrical
-   MER: {id: 9, fov: 360, label: "Mercator"},
+   MER: {id: 9, label: "Mercator"},
    //CAR: {id: 10, fov: 360, label: "plate carrée"},
    //CEA: {id: 11, fov: 360, label: "cylindrical equal area"},
    //CYP: {id: 12, fov: 360, label: "cylindrical perspective"},
    // Pseudo-cylindrical
-   AIT: {id: 13, fov: 1000, label: "Hammer-Aïtoff"},
+   AIT: {id: 13, label: "Hammer-Aïtoff"},
    //PAR: {id: 14, fov: 360, label: "parabolic"},
    //SFL: {id: 15, fov: 360, label: "sanson-flamsteed"},
-   MOL: {id: 16, fov: 1000, label: "Mollweide"},
+   MOL: {id: 16, label: "Mollweide"},
    // Conic
    //COD: {id: 17, fov: 360, label: "conic equidistant"},
    // Hybrid

--- a/src/js/Utils.ts
+++ b/src/js/Utils.ts
@@ -194,6 +194,22 @@ Utils.throttle = function (fn, threshhold, scope) {
     }
 }
 
+// Way of detecting if the computer has trackpad or a regular mouse wheel thanks to that post:
+// https://stackoverflow.com/questions/10744645/detect-touchpad-vs-mouse-in-javascript
+Utils.detectTrackPad = function (e) {
+    var isTrackpad = false;
+    if (e.wheelDeltaY) {
+        if (e.wheelDeltaY === (e.deltaY * -3)) {
+        isTrackpad = true;
+        }
+    }
+    else if (e.deltaMode === 0) {
+        isTrackpad = true;
+    }
+
+    return isTrackpad
+}
+
 
 /* A LRU cache, inspired by https://gist.github.com/devinus/409353#file-gistfile1-js */
 // TODO : utiliser le LRU cache pour les tuiles images


### PR DESCRIPTION
Allow to set the screen zoom factor instead of the aperture in degree. This is projection agnostic which should allow zooming more smootly independently from the projection used.

Targets: #202 and #209

