### PR TITLE
bug: filled moc drawing reverse longitude

### DIFF
--- a/src/core/src/camera/viewport.rs
+++ b/src/core/src/camera/viewport.rs
@@ -5,6 +5,7 @@ pub enum UserAction {
     Moving = 3,
     Starting = 4,
 }
+use web_sys::WebGl2RenderingContext;
 
 // Longitude reversed identity matrix
 const ID_R: &Matrix4<f64> = &Matrix4::new(
@@ -547,6 +548,13 @@ impl CameraViewPort {
     pub fn set_longitude_reversed(&mut self, reversed_longitude: bool, proj: &ProjectionType) {
         if self.reversed_longitude != reversed_longitude {
             self.reversed_longitude = reversed_longitude;
+
+            // Change the cull face, this fixes the display of MOC hpx cells when longitude is reversed
+            if self.reversed_longitude {
+                self.gl.cull_face(WebGl2RenderingContext::FRONT);
+            } else {
+                self.gl.cull_face(WebGl2RenderingContext::BACK);
+            }
 
             self.update_rot_matrices(proj);
         }

--- a/src/core/src/renderable/hips/d2/mod.rs
+++ b/src/core/src/renderable/hips/d2/mod.rs
@@ -671,9 +671,6 @@ impl HiPS2D {
             ..
         } = cfg;
 
-        // Add starting fading
-        //let fading = self.get_fading_factor();
-        //let opacity = opacity * fading;
         // Get the colormap from the color
         let cmap = colormaps.get(color.cmap_name.as_ref());
 

--- a/src/core/src/renderable/moc/mod.rs
+++ b/src/core/src/renderable/moc/mod.rs
@@ -496,14 +496,6 @@ impl MOCIntern {
                     0,
                     num_instances as i32,
                 );
-
-                /*rasterizer.add_stroke_paths(
-                    ,
-                    thickness,
-                    &color,
-                    &super::line::Style::None,
-                    CooSpace::LonLat,
-                );*/
             }
             RenderModeType::Filled { color } => {
                 let mut off_idx = 0;
@@ -523,10 +515,10 @@ impl MOCIntern {
                         ];
 
                         indices.extend_from_slice(&[
+                            off_idx + 0,
+                            off_idx + 2,
                             off_idx + 1,
                             off_idx + 0,
-                            off_idx + 3,
-                            off_idx + 1,
                             off_idx + 3,
                             off_idx + 2,
                         ]);
@@ -552,8 +544,8 @@ impl MOCIntern {
                 let icrs2view = CooSystem::ICRS.to(camera.get_coo_system());
                 let view2world = camera.get_m2w();
                 let icrs2world = view2world * icrs2view;
-
-                //self.gl.enable(WebGl2RenderingContext::BLEND);
+                
+                self.gl.enable(WebGl2RenderingContext::CULL_FACE);
 
                 crate::shader::get_shader(&self.gl, shaders, "moc_base.vert", "moc_base.frag")?
                     .bind(&self.gl)
@@ -569,11 +561,11 @@ impl MOCIntern {
                         0,
                     );
 
-                //self.gl.disable(WebGl2RenderingContext::BLEND);
+                self.gl.disable(WebGl2RenderingContext::CULL_FACE);
             }
         }
+
         Ok(())
-        //});
     }
 
     fn compute_edge_paths_iter<'a>(

--- a/src/core/src/renderable/moc/renderer.rs
+++ b/src/core/src/renderable/moc/renderer.rs
@@ -143,16 +143,12 @@ impl MOCRenderer {
         shaders: &mut ShaderManager,
     ) -> Result<(), JsValue> {
         if !self.is_empty() {
-            self.gl.enable(WebGl2RenderingContext::CULL_FACE);
-
             for (hmoc, cfg) in self.mocs.iter_mut().zip(self.cfgs.iter()) {
                 if cfg.show {
                     let moc = hmoc.select_moc_from_view(camera);
                     moc.draw(camera, proj, shaders)?;
                 }
             }
-
-            self.gl.disable(WebGl2RenderingContext::CULL_FACE);
         }
 
         Ok(())

--- a/src/glsl/webgl2/line/inst_lonlat.vert
+++ b/src/glsl/webgl2/line/inst_lonlat.vert
@@ -27,7 +27,7 @@ void main() {
     vec2 p_b_clip = proj(p_b_w.xyz);
 
     vec2 da = p_a_clip - p_b_clip;
-    l = da.x*da.x + da.y*da.y;
+    l = dot(da, da);
 
     vec2 p_a_ndc = p_a_clip / (ndc_to_clip * czf);
     vec2 p_b_ndc = p_b_clip / (ndc_to_clip * czf);


### PR DESCRIPTION
There was a bug occuring when drawing filled MOC when the longitude axis is reversed (e.g. when displaying a planetary survey). This commit fixes that.
