### PR TITLE
feat: use TAP entry point to query NED

### DIFF
--- a/examples/al-obscore.html
+++ b/examples/al-obscore.html
@@ -17,6 +17,8 @@
         });
 
         aladin.addCatalog(A.catalogFromVizieR("B/assocdata/obscore", "0 +0", 20, {onClick: 'showTable', hoverColor: 'yellow', limit: 1000}))
+        aladin.addCatalog(A.catalogFromSKAORucio("0 +0", 70, {onClick: 'showTable', hoverColor: 'yellow', limit: 1000}))
+
     });
 </script>
 </body>

--- a/src/js/URLBuilder.js
+++ b/src/js/URLBuilder.js
@@ -54,7 +54,8 @@ export let URLBuilder = (function() {
         },
 
         buildNEDPositionCSURL: function(ra, dec, radiusDegrees) {
-            return 'https://ned.ipac.caltech.edu/cgi-bin/nph-objsearch?search_type=Near+Position+Search&of=xml_main&RA=' + ra + '&DEC=' + dec + '&SR=' + radiusDegrees;
+            //OLD return 'https://ned.ipac.caltech.edu/cgi-bin/nph-objsearch?search_type=Near+Position+Search&of=xml_main&RA=' + ra + '&DEC=' + dec + '&SR=' + radiusDegrees;
+            return 'https://ned.ipac.caltech.edu/tap/sync?query=SELECT+*+FROM+objdir+WHERE+CONTAINS(POINT(\'J2000\',ra,dec),CIRCLE(\'J2000\',' + ra + ',' + dec + ',' + radiusDegrees + '))=1&LANG=ADQL&REQUEST=doQuery&FORMAT=votable'
         },
 
         buildNEDObjectCSURL: function(object, radiusDegrees) {


### PR DESCRIPTION
Targets: #49 

What remains to do before merging:

* buildNEDObjectCSURL (with a join in the ADQL query)
* we saw with @tboch that NED is queried through the aladin API. We must ensure changing it is acceptable for users (Alerce broker is one of it)