### PR TITLE
fix: stop contextmenu event propagation only if context menu enabled

### DIFF
--- a/src/js/View.js
+++ b/src/js/View.js
@@ -600,7 +600,9 @@ export let View = (function () {
         Utils.on(view.catalogCanvas, "contextmenu", function (e) {
             // do something here...
             e.preventDefault();
-            e.stopPropagation();
+            if(view.aladin.contextMenu) {
+                e.stopPropagation();
+            }
         }, false);
 
 


### PR DESCRIPTION
Resolves #258 

In the event that the default Aladin context menu is not enabled, the `contextmenu` event may be used for some other UI and so it will need to bubble up.