### PR TITLE
Fix grid labels formatting

### DIFF
--- a/examples/al-easy-access-simbad-ned.html
+++ b/examples/al-easy-access-simbad-ned.html
@@ -20,6 +20,7 @@
         showSettingsControl: true,
         showStackLayerControl: true,
         samp: true,
+        showCooGrid: true,
       });
 
       aladin.addCatalog(A.catalogFromSimbad('M 82', 0.1, {onClick: 'showTable'}));

--- a/src/core/al-api/src/angle.rs
+++ b/src/core/al-api/src/angle.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use std::fmt;
-
 #[wasm_bindgen(raw_module = "../../js/libs/astro/coo.js")]
 extern "C" {
     #[wasm_bindgen(js_name = Format)]
@@ -28,28 +26,11 @@ extern "C" {
     pub fn toDecimal(num: f64, prec: u8) -> String;
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
+use std::cmp::Eq;
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
 #[wasm_bindgen]
-pub enum AngleSerializeFmt {
-    DMM,
-    DD,
-    DMS,
-    HMS,
-}
-
-impl fmt::Display for AngleSerializeFmt {
-    // This trait requires `fmt` with this exact signature.
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Write strictly the first element into the supplied output
-        // stream: `f`. Returns `fmt::Result` which indicates whether the
-        // operation succeeded or failed. Note that `write!` uses syntax which
-        // is very similar to `println!`.
-        let str = match self {
-            Self::DMM => "DMM",
-            Self::DD => "DD",
-            Self::DMS => "DMS",
-            Self::HMS => "HMS",
-        };
-        write!(f, "{}", str)
-    }
+pub enum Formatter {
+    Sexagesimal,
+    Decimal
 }

--- a/src/core/al-api/src/grid.rs
+++ b/src/core/al-api/src/grid.rs
@@ -1,12 +1,9 @@
-use wasm_bindgen::prelude::*;
-
 use serde::{Deserialize, Serialize};
 
-use crate::angle_fmt::AngleSerializeFmt;
+use crate::angle::Formatter;
 
 use super::color::ColorRGB;
 
-#[wasm_bindgen]
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GridCfg {
@@ -22,7 +19,7 @@ pub struct GridCfg {
     #[serde(default = "default_enabled")]
     pub enabled: Option<bool>,
     #[serde(default = "default_fmt")]
-    pub fmt: Option<AngleSerializeFmt>,
+    pub fmt: Option<Formatter>,
 }
 
 fn default_labels() -> Option<bool> {
@@ -45,6 +42,6 @@ fn default_thickness() -> Option<f32> {
     None
 }
 
-fn default_fmt() -> Option<AngleSerializeFmt> {
+fn default_fmt() -> Option<Formatter> {
     None
 }

--- a/src/core/al-api/src/lib.rs
+++ b/src/core/al-api/src/lib.rs
@@ -13,7 +13,7 @@ pub mod resources;
 pub mod cell;
 pub mod fov;
 pub mod image;
-pub mod angle_fmt;
+pub mod angle;
 
 pub trait Abort {
     type Item;

--- a/src/core/src/app.rs
+++ b/src/core/src/app.rs
@@ -20,6 +20,7 @@ use crate::{
     tile_fetcher::TileFetcherQueue,
     time::DeltaTime,
 };
+use crate::math::angle::ToAngle;
 use al_core::image::format::ChannelType;
 use wcs::WCS;
 
@@ -421,7 +422,7 @@ impl App {
                 let v = cell.vertices();
                 let proj2screen = |(lon, lat): &(f64, f64)| -> Option<[f64; 2]> {
                     // 1. convert to xyzw
-                    let xyzw = crate::math::lonlat::radec_to_xyzw(Angle(*lon), Angle(*lat));
+                    let xyzw = crate::math::lonlat::radec_to_xyzw(lon.to_angle(), lat.to_angle());
                     // 2. get it back to the camera frame system
                     let xyzw = crate::coosys::apply_coo_system(
                         CooSystem::ICRS,
@@ -1325,7 +1326,7 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn get_max_fov(&self) -> f64 {
+    pub(crate) fn get_max_fov(&self) -> Angle<f64> {
         self.projection.aperture_start()
     }
 

--- a/src/core/src/camera/mod.rs
+++ b/src/core/src/camera/mod.rs
@@ -41,7 +41,7 @@ pub fn build_fov_coverage(
 
             let hpx_idxs_iter = vertices_iter.map(|v| {
                 let (lon, lat) = crate::math::lonlat::xyzw_to_radec(&v);
-                ::healpix::nested::hash(depth, lon.0, lat.0)
+                ::healpix::nested::hash(depth, lon.to_radians(), lat.to_radians())
             });
 
             HEALPixCoverage::from_fixed_hpx_cells(depth, hpx_idxs_iter, Some(vertices.len()))

--- a/src/core/src/camera/viewport.rs
+++ b/src/core/src/camera/viewport.rs
@@ -88,7 +88,6 @@ const MAX_DPI_LIMIT: f32 = 2.0;
 use crate::math;
 use crate::time::Time;
 use crate::Abort;
-use crate::ArcDeg;
 impl CameraViewPort {
     pub fn new(
         gl: &WebGlContext,
@@ -97,7 +96,7 @@ impl CameraViewPort {
     ) -> CameraViewPort {
         let last_user_action = UserAction::Starting;
 
-        let aperture = Angle(projection.aperture_start());
+        let aperture = projection.aperture_start();
 
         let w2m = Matrix4::identity();
         let m2w = w2m;
@@ -350,12 +349,12 @@ impl CameraViewPort {
             _ => true,
         };
 
-        let aperture_start: Angle<f64> = ArcDeg(proj.aperture_start()).into();
+        let aperture_start = proj.aperture_start();
 
         self.clip_zoom_factor = if aperture > aperture_start {
             //al_core::log(&format!("a: {:?}, as: {:?}", aperture, aperture_start));
             if can_unzoom_more {
-                aperture.0 / aperture_start.0
+                aperture.to_radians() / aperture_start.to_radians()
             } else {
                 1.0
             }
@@ -363,8 +362,8 @@ impl CameraViewPort {
             // Compute the new clip zoom factor
             let a = aperture.abs();
 
-            let v0 = math::lonlat::radec_to_xyzw(-a / 2.0, Angle(0.0));
-            let v1 = math::lonlat::radec_to_xyzw(a / 2.0, Angle(0.0));
+            let v0 = math::lonlat::radec_to_xyzw(-a / 2.0, 0.0.to_angle());
+            let v1 = math::lonlat::radec_to_xyzw(a / 2.0, 0.0.to_angle());
 
             // Vertex in the WCS of the FOV
             if self.width < self.height {

--- a/src/core/src/coosys.rs
+++ b/src/core/src/coosys.rs
@@ -39,8 +39,8 @@ mod tests {
         let gal_lonlat =
             super::apply_coo_system(CooSystem::ICRS, CooSystem::GAL, &lonlat.vector()).lonlat();
 
-        let gal_lon_deg = gal_lonlat.lon().0 * 360.0 / (2.0 * std::f64::consts::PI);
-        let gal_lat_deg = gal_lonlat.lat().0 * 360.0 / (2.0 * std::f64::consts::PI);
+        let gal_lon_deg = gal_lonlat.lon().to_degrees();
+        let gal_lat_deg = gal_lonlat.lat().to_degrees();
 
         assert_delta!(gal_lon_deg, 96.33723581, 1e-3);
         assert_delta!(gal_lat_deg, -60.18845577, 1e-3);
@@ -56,8 +56,8 @@ mod tests {
         let lonlat: LonLatT<f64> = LonLatT::new(ArcDeg(0.0).into(), ArcDeg(0.0).into());
         let j2000_lonlat =
             super::apply_coo_system(CooSystem::GAL, CooSystem::ICRS, &lonlat.vector()).lonlat();
-        let j2000_lon_deg = j2000_lonlat.lon().0 * 360.0 / (2.0 * std::f64::consts::PI);
-        let j2000_lat_deg = j2000_lonlat.lat().0 * 360.0 / (2.0 * std::f64::consts::PI);
+        let j2000_lon_deg = j2000_lonlat.lon().to_degrees();
+        let j2000_lat_deg = j2000_lonlat.lat().to_degrees();
 
         assert_delta!(j2000_lon_deg, 266.40506655, 1e-3);
         assert_delta!(j2000_lat_deg, -28.93616241, 1e-3);
@@ -77,8 +77,8 @@ mod tests {
 
         let gal_lonlat = super::apply_coo_system(CooSystem::ICRS, CooSystem::GAL, &icrs_pos);
 
-        let gal_lon_deg = gal_lonlat.lon().0 * 360.0 / (2.0 * std::f64::consts::PI);
-        let gal_lat_deg = gal_lonlat.lat().0 * 360.0 / (2.0 * std::f64::consts::PI);
+        let gal_lon_deg = gal_lonlat.lon().to_degrees();
+        let gal_lat_deg = gal_lonlat.lat().to_degrees();
 
         assert_delta!(gal_lon_deg, 0.0, 1e-3);
         assert_delta!(gal_lat_deg, 0.0, 1e-3);

--- a/src/core/src/healpix/coverage.rs
+++ b/src/core/src/healpix/coverage.rs
@@ -27,15 +27,14 @@ impl HEALPixCoverage {
         let lonlat = vertices_iter
             .map(|vertex| {
                 let LonLatT(lon, lat) = vertex.lonlat();
-                //let (lon, lat) = math::lonlat::xyzw_to_radec(&vertex);
-                (lon.0, lat.0)
+                (lon.to_radians(), lat.to_radians())
             })
             .collect::<Vec<_>>();
 
         let LonLatT(in_lon, in_lat) = inside.lonlat();
         let moc = RangeMOC::from_polygon_with_control_point(
             &lonlat[..],
-            (in_lon.0, in_lat.0),
+            (in_lon.to_radians(), in_lat.to_radians()),
             depth,
             CellSelection::All,
         );
@@ -84,11 +83,11 @@ impl HEALPixCoverage {
 
     pub fn contains_coo(&self, coo: &Vector4<f64>) -> bool {
         let (lon, lat) = math::lonlat::xyzw_to_radec(coo);
-        self.0.is_in(lon.0, lat.0)
+        self.0.is_in(lon.to_radians(), lat.to_radians())
     }
 
     pub fn contains_lonlat(&self, lonlat: &LonLatT<f64>) -> bool {
-        self.0.is_in(lonlat.lon().0, lonlat.lat().0)
+        self.0.is_in(lonlat.lon().to_radians(), lonlat.lat().to_radians())
     }
 
     // O(log2(N))

--- a/src/core/src/healpix/utils.rs
+++ b/src/core/src/healpix/utils.rs
@@ -1,5 +1,6 @@
 use crate::healpix::cell::HEALPixCell;
-use crate::math::{angle::Angle, lonlat::LonLatT};
+use crate::math::lonlat::LonLatT;
+use crate::math::angle::ToAngle;
 /// A simple wrapper around sore core methods
 /// of cdshealpix
 ///
@@ -17,15 +18,15 @@ pub fn vertices_lonlat<S: BaseFloat>(cell: &HEALPixCell) -> [LonLatT<S>; 4] {
             let lon = S::from(*lon).unwrap_abort();
             let lat = S::from(*lat).unwrap_abort();
 
-            (lon, lat)
+            (lon.to_angle(), lat.to_angle())
         })
         .unzip();
 
     [
-        LonLatT::new(Angle(lon[0]), Angle(lat[0])),
-        LonLatT::new(Angle(lon[1]), Angle(lat[1])),
-        LonLatT::new(Angle(lon[2]), Angle(lat[2])),
-        LonLatT::new(Angle(lon[3]), Angle(lat[3])),
+        LonLatT::new(lon[0], lat[0]),
+        LonLatT::new(lon[1], lat[1]),
+        LonLatT::new(lon[2], lat[2]),
+        LonLatT::new(lon[3], lat[3]),
     ]
 }
 use crate::Abort;
@@ -40,13 +41,13 @@ pub fn grid_lonlat<S: BaseFloat>(cell: &HEALPixCell, n_segments_by_side: u16) ->
             let lon = S::from(*lon).unwrap_abort();
             let lat = S::from(*lat).unwrap_abort();
 
-            LonLatT::new(Angle(lon), Angle(lat))
+            LonLatT::new(lon.to_angle(), lat.to_angle())
         })
         .collect()
 }
 
 pub fn hash_with_dxdy(depth: u8, lonlat: &LonLatT<f64>) -> (u64, f64, f64) {
-    healpix::nested::hash_with_dxdy(depth, lonlat.lon().0, lonlat.lat().0)
+    healpix::nested::hash_with_dxdy(depth, lonlat.lon().to_radians(), lonlat.lat().to_radians())
 }
 
 pub const MEAN_HPX_CELL_RES: &[f64; 30] = &[

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -562,7 +562,7 @@ impl WebClient {
     /// the sinus would be 180 degrees.
     #[wasm_bindgen(js_name = getMaxFieldOfView)]
     pub fn get_max_fov(&mut self) -> f64 {
-        self.app.get_max_fov()
+        self.app.get_max_fov().to_degrees()
     }
 
     /// Get the clip zoom factor of the view

--- a/src/core/src/math/lonlat.rs
+++ b/src/core/src/math/lonlat.rs
@@ -26,8 +26,8 @@ where
     /// * ``lon`` - Longitude
     /// * ``lat`` - Latitude
     pub fn new(mut lon: Angle<S>, lat: Angle<S>) -> LonLatT<S> {
-        if lon.0 < S::zero() {
-            lon.0 = lon.0 + S::from(TWICE_PI).unwrap_abort();
+        if lon.to_radians() < S::zero() {
+            lon = lon + S::from(TWICE_PI).unwrap_abort();
         }
 
         LonLatT(lon, lat)
@@ -156,33 +156,31 @@ where
 #[inline]
 pub fn ang_between_lonlat<S: BaseFloat>(lonlat1: LonLatT<S>, lonlat2: LonLatT<S>) -> Angle<S> {
     let abs_diff_lon = (lonlat1.lon() - lonlat2.lon()).abs();
-    Angle(
-        (lonlat1.lat().sin() * lonlat2.lat().sin()
-            + lonlat1.lat().cos() * lonlat2.lat().cos() * abs_diff_lon.cos())
-        .acos(),
-    )
+    (lonlat1.lat().sin() * lonlat2.lat().sin()
+        + lonlat1.lat().cos() * lonlat2.lat().cos() * abs_diff_lon.cos())
+    .acos().to_angle()
 }
 
 #[inline]
 pub fn xyz_to_radec<S: BaseFloat>(v: &Vector3<S>) -> (Angle<S>, Angle<S>) {
-    let lon = Angle(v.x.atan2(v.z));
-    let lat = Angle(v.y.atan2((v.x * v.x + v.z * v.z).sqrt()));
+    let lon = (v.x.atan2(v.z)).to_angle();
+    let lat = (v.y.atan2((v.x * v.x + v.z * v.z).sqrt())).to_angle();
 
     (lon, lat)
 }
 
 #[inline]
 pub fn xyzw_to_radec<S: BaseFloat>(v: &Vector4<S>) -> (Angle<S>, Angle<S>) {
-    let lon = Angle(v.x.atan2(v.z));
-    let lat = Angle(v.y.atan2((v.x * v.x + v.z * v.z).sqrt()));
+    let lon = (v.x.atan2(v.z)).to_angle();
+    let lat = (v.y.atan2((v.x * v.x + v.z * v.z).sqrt())).to_angle();
 
     (lon, lat)
 }
 
 #[inline]
 pub fn radec_to_xyz<S: BaseFloat>(theta: Angle<S>, delta: Angle<S>) -> Vector3<S> {
-    let (ds, dc) = delta.0.sin_cos();
-    let (ts, tc) = theta.0.sin_cos();
+    let (ds, dc) = delta.to_radians().sin_cos();
+    let (ts, tc) = theta.to_radians().sin_cos();
 
     Vector3::<S>::new(dc * ts, ds, dc * tc)
 }

--- a/src/core/src/math/projection/mod.rs
+++ b/src/core/src/math/projection/mod.rs
@@ -19,8 +19,10 @@ use cgmath::Vector2;
 pub mod coo_space;
 pub mod domain;
 
-use domain::{basic, full::FullScreen};
+use crate::math::angle::ToAngle;
 
+use domain::{basic, full::FullScreen};
+use crate::math::angle::Angle;
 /* S <-> NDC space conversion methods */
 pub fn screen_to_ndc_space(
     pos_screen_space: &XYScreen<f64>,
@@ -304,7 +306,7 @@ impl ProjectionType {
         }
     }*/
 
-    pub fn bounds_size_ratio(&self) -> f64 {
+    pub const fn bounds_size_ratio(&self) -> f64 {
         match self {
             // Zenithal projections
             /* TAN,      Gnomonic projection        */
@@ -355,17 +357,17 @@ impl ProjectionType {
         }
     }
 
-    pub fn aperture_start(&self) -> f64 {
+    pub fn aperture_start(&self) -> Angle<f64> {
         match self {
             // Zenithal projections
             /* TAN,      Gnomonic projection        */
-            ProjectionType::Tan(_) => 150.0,
+            ProjectionType::Tan(_) => 150.0_f64.to_radians().to_angle(),
             /* STG,	     Stereographic projection   */
-            ProjectionType::Stg(_) => 360.0,
+            ProjectionType::Stg(_) => 360.0_f64.to_radians().to_angle(),
             /* SIN,	     Orthographic		        */
-            ProjectionType::Sin(_) => 180.0,
+            ProjectionType::Sin(_) => 180.0_f64.to_radians().to_angle(),
             /* ZEA,	     Equal-area 		        */
-            ProjectionType::Zea(_) => 360.0,
+            ProjectionType::Zea(_) => 360.0_f64.to_radians().to_angle(),
             /* FEYE,     Fish-eyes                  */
             //ProjectionType::Feye(_) => 190.0,
             /* AIR,                                 */
@@ -379,9 +381,9 @@ impl ProjectionType {
 
             // Pseudo-cylindrical projections
             /* AIT,      Aitoff                     */
-            ProjectionType::Ait(_) => 360.0,
+            ProjectionType::Ait(_) => 360.0_f64.to_radians().to_angle(),
             // MOL,      Mollweide                  */
-            ProjectionType::Mol(_) => 360.0,
+            ProjectionType::Mol(_) => 360.0_f64.to_radians().to_angle(),
             // PAR,                                 */
             //ProjectionType::Par(_) => 360.0,
             // SFL,                                 */
@@ -389,7 +391,7 @@ impl ProjectionType {
 
             // Cylindrical projections
             // MER,      Mercator                   */
-            ProjectionType::Mer(_) => 360.0,
+            ProjectionType::Mer(_) => 360.0_f64.to_radians().to_angle(),
             // CAR,                                 */
             //ProjectionType::Car(_) => 360.0,
             // CEA,                                 */

--- a/src/core/src/math/rotation.rs
+++ b/src/core/src/math/rotation.rs
@@ -2,6 +2,7 @@ use crate::math;
 use cgmath::{BaseFloat, InnerSpace};
 use cgmath::{Euler, Quaternion};
 use cgmath::{Vector3, Vector4};
+use crate::math::angle::ToAngle;
 
 #[derive(Clone, Copy, Debug)]
 // Internal structure of a rotation, a quaternion
@@ -159,7 +160,7 @@ where
         let a = m.x.z.atan2(m.z.z);
         let b = (-m.z.y).atan2((S::one() - m.z.y * m.z.y).sqrt());
         let c = m.x.y.atan2(m.y.y);
-        (Angle(a), Angle(b), Angle(c))
+        (a.to_angle(), b.to_angle(), c.to_angle())
     }
 }
 

--- a/src/core/src/math/vector.rs
+++ b/src/core/src/math/vector.rs
@@ -1,15 +1,16 @@
 use crate::math::angle::Angle;
 use cgmath::{BaseFloat, InnerSpace, Vector2, Vector3};
+use crate::math::angle::ToAngle;
 
 #[inline]
 pub fn angle2<S: BaseFloat>(ab: &Vector2<S>, bc: &Vector2<S>) -> Angle<S> {
-    Angle((ab.dot(*bc)).acos())
+    ((ab.dot(*bc)).acos()).to_angle()
 }
 
 #[inline]
 pub fn angle3<S: BaseFloat>(x: &Vector3<S>, y: &cgmath::Vector3<S>) -> Angle<S> {
     let theta = x.cross(*y).magnitude().atan2(x.dot(*y));
-    Angle(theta)
+    theta.to_angle()
 }
 
 #[inline]

--- a/src/core/src/renderable/hips/d2/mod.rs
+++ b/src/core/src/renderable/hips/d2/mod.rs
@@ -19,7 +19,6 @@ use al_core::VecData;
 use al_core::VertexArrayObject;
 use al_core::WebGlContext;
 
-use crate::math::angle::Angle;
 use crate::ProjectionType;
 
 use crate::camera::CameraViewPort;
@@ -31,6 +30,8 @@ use crate::downloader::request::allsky::Allsky;
 use crate::healpix::{cell::HEALPixCell, coverage::HEALPixCoverage};
 use crate::renderable::utils::index_patch::DefaultPatchIndexIter;
 use crate::time::Time;
+use crate::math::angle::ToAngle;
+
 
 use super::config::HiPSConfig;
 use std::collections::HashSet;
@@ -565,7 +566,7 @@ impl HiPS2D {
                         self.uv_end.extend(uv_end);
                         self.time_tile_received.push(start_time);
 
-                        let xyz = crate::math::lonlat::radec_to_xyz(Angle(lon), Angle(lat));
+                        let xyz = crate::math::lonlat::radec_to_xyz(lon.to_angle(), lat.to_angle());
                         pos.push([xyz.x as f32, xyz.y as f32, xyz.z as f32]);
                         //pos.push([lon as f32, lat as f32]);
                     }

--- a/src/core/src/renderable/hips/subdivide.rs
+++ b/src/core/src/renderable/hips/subdivide.rs
@@ -1,19 +1,17 @@
 use crate::camera::CameraViewPort;
-use crate::math::angle::Angle;
 use crate::math::projection::ProjectionType;
 use crate::math::vector::dist2;
 use crate::HEALPixCell;
-
+use crate::math::angle::ToAngle;
 const M: f64 = 280.0 * 280.0;
 const N: f64 = 150.0 * 150.0;
 const RAP: f64 = 0.7;
-
 fn is_too_large(cell: &HEALPixCell, camera: &CameraViewPort, projection: &ProjectionType) -> bool {
     let vertices = cell
         .vertices()
         .iter()
         .filter_map(|(lon, lat)| {
-            let vertex = crate::math::lonlat::radec_to_xyzw(Angle(*lon), Angle(*lat));
+            let vertex = crate::math::lonlat::radec_to_xyzw(lon.to_angle(), lat.to_angle());
             projection.icrs_celestial_to_screen_space(&vertex, camera)
         })
         .collect::<Vec<_>>();

--- a/src/js/Aladin.js
+++ b/src/js/Aladin.js
@@ -1416,6 +1416,12 @@ export let Aladin = (function () {
         this.view.showCatalog(show);
     };
 
+    /**
+     * Show/Hide the reticle centered on the view
+     *
+     * @memberof Aladin
+     * @param {boolean} show - True to enable, false to hide
+     */
     Aladin.prototype.showReticle = function (show) {
         this.reticle.update({ show });
     };
@@ -1433,6 +1439,12 @@ export let Aladin = (function () {
         });
     };
 
+     /**
+     * Add a overlay of shapes/footprints to the view
+     *
+     * @memberof Aladin
+     * @param {GraphicOverlay} overlay - The shapes/footprints overlay to add
+     */
     Aladin.prototype.addOverlay = function (overlay) {
         this.view.addOverlay(overlay);
 
@@ -1441,10 +1453,15 @@ export let Aladin = (function () {
         });
     };
 
+
+    /**
+     * Add a Multi-Order Coverage map (MOC) to the view
+     *
+     * @memberof Aladin
+     * @param {MOC} moc - The MOC object to add
+     */
     Aladin.prototype.addMOC = function (moc) {
         this.view.addMOC(moc);
-
-        // see MOC.setView for sending it to outside the UI
     };
 
     Aladin.prototype.removeUIByName = function(name) {
@@ -3077,13 +3094,6 @@ aladin.displayFITS(
             cmaps: this.getListOfColormaps()
         });
     };
-
-    /*
-    Aladin.prototype.setReduceDeformations = function (reduce) {
-        this.reduceDeformations = reduce;
-        this.view.requestRedraw();
-    }
-    */
 
     return Aladin;
 })();

--- a/src/js/AladinUtils.js
+++ b/src/js/AladinUtils.js
@@ -208,6 +208,7 @@ export let AladinUtils = {
         * // returns "36 arcsec"
         * Numbers.degreesToString(0.01);
         */
+        // FIXME: Same as in the libs/astro/angle.js
         degreesToString: function(numberDegrees) {
             let setPrecision = 3
             let degrees = numberDegrees | 0;

--- a/src/js/View.js
+++ b/src/js/View.js
@@ -1966,11 +1966,11 @@ export let View = (function () {
         }
 
         // Set the grid label format
-        if (this.cooFrame.label == "ICRSd") {
-            this.setGridOptions({fmt: "HMS"});
+        if (this.cooFrame.label == "ICRS") {
+            this.setGridOptions({fmt: "sexagesimal"});
         }
         else {
-            this.setGridOptions({fmt: "DMS"});
+            this.setGridOptions({fmt: "decimal"});
         }
 
         // Get the new view center position (given in icrs)


### PR DESCRIPTION
Two modes of display:
* ICRSd & GALACTIC frame set the formatting of grid labels to decimal
with digit precision being computed from the grid step selected
* ICRS frame set the formatting to sexagesimal in the format: deg min
sec.ddd .

This fixes #172 