### PR TITLE
feat: shape function given to a catalog

### DIFF
--- a/src/js/Source.js
+++ b/src/js/Source.js
@@ -122,6 +122,10 @@ export let Source = (function() {
         this.image = image;
     }
 
+    Source.prototype.setShape = function(shape) {
+        this.shape = shape;
+    }
+
     /**
      * Simulates a click on the source
      *

--- a/src/js/View.js
+++ b/src/js/View.js
@@ -1584,14 +1584,14 @@ export let View = (function () {
 
     View.prototype.increaseZoom = function () {
         this.zoom.apply({
-            stop: this.fov / 1.4,
+            stop: this.fov / 1.8,
             duration: 100
         });
     }
 
     View.prototype.decreaseZoom = function () {
         this.zoom.apply({
-            stop: this.fov * 1.4,
+            stop: this.fov * 1.8,
             duration: 100
         });
     }

--- a/src/js/shapes/Polyline.js
+++ b/src/js/shapes/Polyline.js
@@ -73,31 +73,6 @@ export let Polyline = (function() {
         }
     }
 
-    /*function _isAcrossCollignonZoneForHpxProjection(line, view) {
-        const [x1, y1] = view.wasm.screenToClip(line.x1, line.y1);
-        const [x2, y2] = view.wasm.screenToClip(line.x2, line.y2);
-
-        // x, y, between -1 and 1
-        let triIdxCollignionZone = function(x, y) {
-            let xZone = Math.floor((x * 0.5 + 0.5) * 4.0);
-            return xZone + 4 * (y > 0.0);
-        };
-
-        let isInCollignionZone = function(x, y) {
-            return Math.abs(y) > 0.5;
-        };
-
-        if (isInCollignionZone(x1, y1) && isInCollignionZone(x2, y2)) {
-            if (triIdxCollignionZone(x1, y1) === triIdxCollignionZone(x2, y2)) {
-                return false;
-            } else {
-                return true;
-            }
-        }
-
-        return false;
-    }*/
-
     /**
      * Represents a polyline shape
      *
@@ -237,7 +212,6 @@ export let Polyline = (function() {
             return;
         }
 
-        console.log(color)
         this.hoverColor = color;
         if (this.overlay) {
             this.overlay.reportChange();


### PR DESCRIPTION
Targets #200 (not all of it)

* :bug: : returning nothing or an invalid value from it will display the source as the square shape. Before, it was forgetting to display the source. This is thus a "fix"
* Possibility to return a string in "rhomb", "circle", "square", "cross", "triangle" from it.
* Set the color of footprint to the color of the Catalog. This thus overwrites the color that could have been given in the footprint directly. To compensate that, I think it could be great to allow a CatalogOptions.color func as well.