### PR TITLE
fix: ICRS to FK5J2000 cooframe renaming

### DIFF
--- a/src/core/al-api/src/coo_system.rs
+++ b/src/core/al-api/src/coo_system.rs
@@ -1,119 +1,66 @@
 use cgmath::Matrix4;
-pub trait CooBaseFloat: Sized + 'static {
-    const GALACTIC_TO_J2000: &'static Matrix4<Self>;
-    const J2000_TO_GALACTIC: &'static Matrix4<Self>;
-    const ID: &'static Matrix4<Self>;
-}
 
-impl CooBaseFloat for f32 {
-    const GALACTIC_TO_J2000: &'static Matrix4<Self> = &Matrix4::new(
-        -0.444_829_64,
-        0.746_982_2,
-        0.494_109_42,
-        0.0,
-        -0.198_076_37,
-        0.455_983_8,
-        -0.867_666_1,
-        0.0,
-        -0.873_437_1,
-        -0.483_835,
-        -0.054_875_56,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    );
+const GAL2FK5J2000: &'static Matrix4<f64> = &Matrix4::new(
+    -0.44482962996001117814661406161609,
+    0.74698224449721889052738800455594,
+    0.49410942787558367352522237135824,
+    0.0,
+    -0.19807637343120152818048609141212,
+    0.45598377617506692227210047834778,
+    -0.86766614901900470118161653456955,
+    0.0,
+    -0.87343709023488504876038316840868,
+    -0.48383501554871322683177417511638,
+    -0.05487556041621536849239890045391,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.0,
+);
 
-    const J2000_TO_GALACTIC: &'static Matrix4<Self> = &Matrix4::new(
-        -0.444_829_64,
-        -0.198_076_37,
-        -0.873_437_1,
-        0.0,
-        0.746_982_2,
-        0.455_983_8,
-        -0.483_835,
-        0.0,
-        0.494_109_42,
-        -0.867_666_1,
-        -0.054_875_56,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    );
+const FK5J20002GAL: &'static Matrix4<f64> = &Matrix4::new(
+    -0.44482962996001117814661406161609,
+    -0.19807637343120152818048609141212,
+    -0.87343709023488504876038316840868,
+    0.0,
+    0.74698224449721889052738800455594,
+    0.45598377617506692227210047834778,
+    -0.48383501554871322683177417511638,
+    0.0,
+    0.49410942787558367352522237135824,
+    -0.86766614901900470118161653456955,
+    -0.05487556041621536849239890045391,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.0,
+);
 
-    const ID: &'static Matrix4<Self> = &Matrix4::new(
-        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
-    );
-}
-impl CooBaseFloat for f64 {
-    const GALACTIC_TO_J2000: &'static Matrix4<Self> = &Matrix4::new(
-        -0.4448296299195045,
-        0.7469822444763707,
-        0.4941094279435681,
-        0.0,
-        -0.1980763734646737,
-        0.4559837762325372,
-        -0.867_666_148_981_161,
-        0.0,
-        -0.873437090247923,
-        -0.4838350155267381,
-        -0.0548755604024359,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    );
+const ID: &'static Matrix4<f64> = &Matrix4::new(
+    1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+);
 
-    const J2000_TO_GALACTIC: &'static Matrix4<Self> = &Matrix4::new(
-        -0.4448296299195045,
-        -0.1980763734646737,
-        -0.873437090247923,
-        0.0,
-        0.7469822444763707,
-        0.4559837762325372,
-        -0.4838350155267381,
-        0.0,
-        0.4941094279435681,
-        -0.867_666_148_981_161,
-        -0.0548755604024359,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    );
 
-    const ID: &'static Matrix4<Self> = &Matrix4::new(
-        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
-    );
-}
-
-use cgmath::BaseFloat;
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize, Hash)]
 pub enum CooSystem {
-    ICRS = 0,
-    GAL = 1,
+    FK5J2000,
+    GAL,
 }
 
 pub const NUM_COOSYSTEM: usize = 2;
 
 impl CooSystem {
     #[inline]
-    pub fn to<S>(&self, coo_system: Self) -> &Matrix4<S>
-    where
-        S: BaseFloat + CooBaseFloat,
-    {
+    pub fn to(&self, coo_system: Self) -> &Matrix4<f64> {
         match (self, coo_system) {
-            (CooSystem::GAL, CooSystem::ICRS) => S::GALACTIC_TO_J2000,
-            (CooSystem::ICRS, CooSystem::GAL) => S::J2000_TO_GALACTIC,
-            (_, _) => S::ID,
+            (CooSystem::GAL, CooSystem::FK5J2000) => GAL2FK5J2000,
+            (CooSystem::FK5J2000, CooSystem::GAL) => FK5J20002GAL,
+            (_, _) => ID,
         }
     }
 }

--- a/src/core/al-api/src/hips.rs
+++ b/src/core/al-api/src/hips.rs
@@ -29,6 +29,7 @@ use crate::coo_system::CooSystem;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[wasm_bindgen]
 pub struct HiPSProperties {
     // Associated with the HiPS
     url: String,

--- a/src/core/src/app.rs
+++ b/src/core/src/app.rs
@@ -147,7 +147,7 @@ impl App {
         // The tile buffer responsible for the tile requests
         let downloader = Rc::new(RefCell::new(Downloader::new()));
 
-        let camera = CameraViewPort::new(&gl, CooSystem::ICRS, &projection);
+        let camera = CameraViewPort::new(&gl, CooSystem::FK5J2000, &projection);
         let screen_size = &camera.get_screen_size();
 
         let _fbo_view =
@@ -403,20 +403,20 @@ impl App {
     }
 
     pub(crate) fn get_visible_cells(&self, depth: u8) -> Box<[HEALPixCellProjeted]> {
-        // Convert the camera frame vertices to icrs before doing the moc
+        // Convert the camera frame vertices to j2000 before doing the moc
         let coverage = crate::camera::build_fov_coverage(
             depth,
             self.camera.get_field_of_view(),
             self.camera.get_center(),
             self.camera.get_coo_system(),
-            CooSystem::ICRS,
+            CooSystem::FK5J2000,
             &self.projection,
         );
 
         let cells: Vec<_> = coverage
             .flatten_to_fixed_depth_cells()
             .filter_map(|ipix| {
-                // this cell is defined in ICRS
+                // This cell is defined in FK5J2000
                 let cell = HEALPixCell(depth, ipix);
 
                 let v = cell.vertices();
@@ -425,7 +425,7 @@ impl App {
                     let xyzw = crate::math::lonlat::radec_to_xyzw(lon.to_angle(), lat.to_angle());
                     // 2. get it back to the camera frame system
                     let xyzw = crate::coosys::apply_coo_system(
-                        CooSystem::ICRS,
+                        CooSystem::FK5J2000,
                         self.camera.get_coo_system(),
                         &xyzw,
                     );
@@ -1421,10 +1421,10 @@ impl App {
 
     pub(crate) fn world_to_screen(&self, ra: f64, dec: f64) -> Option<Vector2<f64>> {
         let lonlat = LonLatT::new(ArcDeg(ra).into(), ArcDeg(dec).into());
-        let icrs_pos = lonlat.vector();
+        let j2000_pos = lonlat.vector();
 
         self.projection
-            .icrs_celestial_to_screen_space(&icrs_pos, &self.camera)
+            .j2000_celestial_to_screen_space(&j2000_pos, &self.camera)
     }
 
     pub(crate) fn screen_to_world(&self, pos: &Vector2<f64>) -> Option<LonLatT<f64>> {
@@ -1443,19 +1443,19 @@ impl App {
         self.camera.get_coo_system()
     }
 
-    pub(crate) fn view_to_icrs_coosys(&self, lonlat: &LonLatT<f64>) -> LonLatT<f64> {
-        let icrs_pos: Vector4<_> = lonlat.vector();
+    pub(crate) fn view_to_fk5j2000_coosys(&self, lonlat: &LonLatT<f64>) -> LonLatT<f64> {
+        let celestial_pos: Vector4<_> = lonlat.vector();
         let view_system = self.camera.get_coo_system();
         let (ra, dec) = math::lonlat::xyzw_to_radec(&coosys::apply_coo_system(
             view_system,
-            CooSystem::ICRS,
-            &icrs_pos,
+            CooSystem::FK5J2000,
+            &celestial_pos,
         ));
 
         LonLatT::new(ra, dec)
     }
 
-    /// lonlat must be given in icrs frame
+    /// lonlat must be given in j2000 frame
     pub(crate) fn set_center(&mut self, lonlat: &LonLatT<f64>) {
         self.prev_cam_position = self.camera.get_center().truncate();
 

--- a/src/core/src/camera/mod.rs
+++ b/src/core/src/camera/mod.rs
@@ -21,7 +21,7 @@ pub fn build_fov_coverage(
 ) -> HEALPixCoverage {
     if let Some(vertices) = fov.get_vertices() {
         // The vertices coming from the camera are in a specific coo sys
-        // but cdshealpix accepts them to be given in ICRS coo sys
+        // but cdshealpix accepts them to be given in FK5J2000 coo sys
         let vertices_iter = vertices
             .iter()
             .map(|v| crate::coosys::apply_coo_system(camera_frame, frame, v));

--- a/src/core/src/camera/view_hpx_cells.rs
+++ b/src/core/src/camera/view_hpx_cells.rs
@@ -16,7 +16,7 @@ impl ViewHpxCells {
     pub(super) fn new() -> Self {
         let reg_frames = [0; NUM_COOSYSTEM];
         let hpx_cells = [
-            HpxCells::new(CooSystem::ICRS),
+            HpxCells::new(CooSystem::FK5J2000),
             HpxCells::new(CooSystem::GAL),
         ];
 
@@ -116,7 +116,7 @@ pub struct HpxCells {
 
 impl Default for HpxCells {
     fn default() -> Self {
-        Self::new(CooSystem::ICRS)
+        Self::new(CooSystem::FK5J2000)
     }
 }
 

--- a/src/core/src/camera/viewport.rs
+++ b/src/core/src/camera/viewport.rs
@@ -484,11 +484,11 @@ impl CameraViewPort {
         self.update_rot_matrices(proj);
     }
 
-    /// center lonlat must be given in icrs frame
+    /// center lonlat must be given in j2000 frame
     pub fn set_center(&mut self, lonlat: &LonLatT<f64>, proj: &ProjectionType) {
-        let icrs_pos: Vector4<_> = lonlat.vector();
+        let j2000_pos: Vector4<_> = lonlat.vector();
 
-        let view_pos = CooSystem::ICRS.to(self.get_coo_system()) * icrs_pos;
+        let view_pos = CooSystem::FK5J2000.to(self.get_coo_system()) * j2000_pos;
         let rot_to_center = Rotation::from_sky_position(&view_pos);
 
         let phi = self.get_center_pos_angle();

--- a/src/core/src/coosys.rs
+++ b/src/core/src/coosys.rs
@@ -1,20 +1,13 @@
-use cgmath::{BaseFloat, Vector4};
-
-use al_api::coo_system::CooBaseFloat;
+use cgmath::Vector4;
 use al_api::coo_system::CooSystem;
-
 
 /// This is conversion method returning a transformation
 /// matrix when the system requested by the user is not
-/// icrs j2000.
-/// The core projections are always performed in icrs j2000
-/// so one must call these methods to convert them to icrs before.
+/// fk5j2000.
+/// The core projections are always performed in fk5j2000
 #[inline]
-pub fn apply_coo_system<S>(c1: CooSystem, c2: CooSystem, v: &Vector4<S>) -> Vector4<S>
-where
-    S: BaseFloat + CooBaseFloat,
-{
-    let c1_2_c2_mat = c1.to::<S>(c2);
+pub fn apply_coo_system(c1: CooSystem, c2: CooSystem, v: &Vector4<f64>) -> Vector4<f64> {
+    let c1_2_c2_mat = c1.to(c2);
     c1_2_c2_mat * (*v)
 }
 
@@ -37,7 +30,7 @@ mod tests {
 
         let lonlat: LonLatT<f64> = LonLatT::new(ArcDeg(0.0).into(), ArcDeg(0.0).into());
         let gal_lonlat =
-            super::apply_coo_system(CooSystem::ICRS, CooSystem::GAL, &lonlat.vector()).lonlat();
+            super::apply_coo_system(CooSystem::FK5J2000, CooSystem::GAL, &lonlat.vector()).lonlat();
 
         let gal_lon_deg = gal_lonlat.lon().to_degrees();
         let gal_lat_deg = gal_lonlat.lat().to_degrees();
@@ -55,7 +48,7 @@ mod tests {
 
         let lonlat: LonLatT<f64> = LonLatT::new(ArcDeg(0.0).into(), ArcDeg(0.0).into());
         let j2000_lonlat =
-            super::apply_coo_system(CooSystem::GAL, CooSystem::ICRS, &lonlat.vector()).lonlat();
+            super::apply_coo_system(CooSystem::GAL, CooSystem::FK5J2000, &lonlat.vector()).lonlat();
         let j2000_lon_deg = j2000_lonlat.lon().to_degrees();
         let j2000_lat_deg = j2000_lonlat.lat().to_degrees();
 
@@ -72,10 +65,10 @@ mod tests {
 
         let gal_lonlat: LonLatT<f64> = LonLatT::new(ArcDeg(0.0).into(), ArcDeg(0.0).into());
 
-        let icrs_pos =
-            super::apply_coo_system(CooSystem::GAL, CooSystem::ICRS, &gal_lonlat.vector());
+        let j2000_pos =
+            super::apply_coo_system(CooSystem::GAL, CooSystem::FK5J2000, &gal_lonlat.vector());
 
-        let gal_lonlat = super::apply_coo_system(CooSystem::ICRS, CooSystem::GAL, &icrs_pos);
+        let gal_lonlat = super::apply_coo_system(CooSystem::FK5J2000, CooSystem::GAL, &j2000_pos);
 
         let gal_lon_deg = gal_lonlat.lon().to_degrees();
         let gal_lat_deg = gal_lonlat.lat().to_degrees();

--- a/src/core/src/healpix/cell.rs
+++ b/src/core/src/healpix/cell.rs
@@ -207,7 +207,7 @@ impl HEALPixCell {
         }
     }
 
-    // Given in ICRS(J2000)
+    // Given in FK5J2000
     #[inline]
     pub fn new(depth: u8, theta: f64, delta: f64) -> Self {
         let pix = healpix::nested::hash(depth, theta, delta);

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -485,7 +485,8 @@ impl WebClient {
     ///
     /// * `coo_system` - The coordinate system
     #[wasm_bindgen(js_name = setCooSystem)]
-    pub fn set_coo_system(&mut self, coo_system: CooSystem) -> Result<(), JsValue> {
+    pub fn set_coo_system(&mut self, coo_system: String) -> Result<(), JsValue> {
+        let coo_system = serde_wasm_bindgen::from_value(coo_system.into())?;
         self.app.set_coo_system(coo_system);
 
         Ok(())
@@ -576,9 +577,9 @@ impl WebClient {
         Ok(self.app.get_clip_zoom_factor())
     }
 
-    /// Set the center of the view in ICRS coosys
+    /// Set the center of the view in FK5J2000 coosys
     ///
-    /// The core works in ICRS system so
+    /// The core works in FK5J2000 system so
     /// the location must be given in this system
     ///
     /// # Arguments
@@ -626,19 +627,19 @@ impl WebClient {
         Ok(())
     }
 
-    /// View frame to ICRS/J2000 coosys conversion
+    /// View frame to FK5J2000 coosys conversion
     ///
-    /// Coordinates must be given in the ICRS coo system
+    /// Coordinates must be given in the FK5J2000 coo system
     ///
     /// # Arguments
     ///
     /// * `lon` - A longitude in degrees
     /// * `lat` - A latitude in degrees
-    #[wasm_bindgen(js_name = viewToICRSCooSys)]
-    pub fn view_to_icrs_coosys(&self, lon: f64, lat: f64) -> Box<[f64]> {
+    #[wasm_bindgen(js_name = viewToFK5J2000CooSys)]
+    pub fn view_to_fk5j2000_coosys(&self, lon: f64, lat: f64) -> Box<[f64]> {
         let lonlat = LonLatT::new(ArcDeg(lon).into(), ArcDeg(lat).into());
 
-        let res = self.app.view_to_icrs_coosys(&lonlat);
+        let res = self.app.view_to_fk5j2000_coosys(&lonlat);
 
         let lon_deg: ArcDeg<f64> = res.lon().into();
         let lat_deg: ArcDeg<f64> = res.lat().into();
@@ -648,7 +649,8 @@ impl WebClient {
 
     /// World to screen projection
     ///
-    /// Coordinates must be given in the ICRS coo system
+    /// Coordinates must be given in the FK5J2000 or ICRS coo system
+    /// ICRS coordinates are lightly different from FK5J2000 but for aladin lite visualization purposes the different is not noticeable.
     ///
     /// # Arguments
     ///
@@ -666,7 +668,7 @@ impl WebClient {
             use crate::math::lonlat::LonLat;
             let xyz =
                 LonLatT::new(lon.to_radians().to_angle(), lat.to_radians().to_angle()).vector();
-            let lonlat = coosys::apply_coo_system(frame, CooSystem::ICRS, &xyz).lonlat();
+            let lonlat = coosys::apply_coo_system(frame, CooSystem::FK5J2000, &xyz).lonlat();
             lon = lonlat.lon().to_degrees();
             lat = lonlat.lat().to_degrees();
         }

--- a/src/core/src/math/projection/mod.rs
+++ b/src/core/src/math/projection/mod.rs
@@ -220,25 +220,25 @@ impl ProjectionType {
         self.world_to_screen_space(&pos_world_space, camera)
     }
 
-    pub fn icrs_celestial_to_screen_space(
+    pub fn j2000_celestial_to_screen_space(
         &self,
-        icrs_celestial_pos: &XYZWModel<f64>,
+        celestial_pos: &XYZWModel<f64>,
         camera: &CameraViewPort,
     ) -> Option<XYScreen<f64>> {
-        self.icrs_celestial_to_normalized_device_space(icrs_celestial_pos, camera)
+        self.j2000_celestial_to_normalized_device_space(celestial_pos, camera)
             .map(|ndc_pos| crate::ndc_to_screen_space(&ndc_pos, camera))
     }
 
-    pub fn icrs_celestial_to_normalized_device_space(
+    pub fn j2000_celestial_to_normalized_device_space(
         &self,
-        icrs_celestial_pos: &XYZWModel<f64>,
+        celestial_pos: &XYZWModel<f64>,
         camera: &CameraViewPort,
     ) -> Option<XYNDC<f64>> {
         let view_coosys = camera.get_coo_system();
-        let c = CooSystem::ICRS.to::<f64>(view_coosys);
+        let c = CooSystem::FK5J2000.to(view_coosys);
 
         let m2w = camera.get_m2w();
-        let pos_world_space = m2w * c * icrs_celestial_pos;
+        let pos_world_space = m2w * c * celestial_pos;
         self.world_to_normalized_device_space(&pos_world_space, camera)
     }
 

--- a/src/core/src/math/rotation.rs
+++ b/src/core/src/math/rotation.rs
@@ -7,12 +7,12 @@ use crate::math::angle::ToAngle;
 #[derive(Clone, Copy, Debug)]
 // Internal structure of a rotation, a quaternion
 // All operations are done on it
-pub struct Rotation<S: BaseFloat + CooBaseFloat>(pub Quaternion<S>);
+pub struct Rotation<S: BaseFloat>(pub Quaternion<S>);
 
 use cgmath::{Matrix3, Matrix4};
 impl<S> From<&Matrix4<S>> for Rotation<S>
 where
-    S: BaseFloat + CooBaseFloat,
+    S: BaseFloat,
 {
     fn from(m: &Matrix4<S>) -> Self {
         let m: [[S; 4]; 4] = (*m).into();
@@ -26,19 +26,18 @@ where
 }
 impl<S> From<&Rotation<S>> for Matrix4<S>
 where
-    S: BaseFloat + CooBaseFloat,
+    S: BaseFloat,
 {
     fn from(s: &Rotation<S>) -> Self {
         s.0.into()
     }
 }
 use crate::math::angle::Angle;
-use al_api::coo_system::CooBaseFloat;
 use cgmath::Matrix;
 use cgmath::Rad;
 impl<S> Rotation<S>
 where
-    S: BaseFloat + CooBaseFloat,
+    S: BaseFloat,
 {
     pub fn slerp(&self, other: &Rotation<S>, alpha: S) -> Rotation<S> {
         // Check if the dot of the two quaternions is negative
@@ -167,7 +166,7 @@ where
 use std::ops::Mul;
 impl<S> Mul<Rotation<S>> for Rotation<S>
 where
-    S: BaseFloat + CooBaseFloat,
+    S: BaseFloat,
 {
     type Output = Self;
 

--- a/src/core/src/renderable/catalog/manager.rs
+++ b/src/core/src/renderable/catalog/manager.rs
@@ -194,7 +194,7 @@ impl Manager {
         // Update the number of sources loaded
         //self.num_sources += num_instances_in_catalog as usize;
         self.catalogs.insert(name, catalog);
-        camera.register_view_frame(CooSystem::ICRS, proj);
+        camera.register_view_frame(CooSystem::FK5J2000, proj);
 
         // At this point, all the sources memory will be deallocated here
         // These sources have been copied to the GPU so we do not need them
@@ -213,7 +213,7 @@ impl Manager {
         // Update the number of sources loaded
         //self.num_sources += num_instances_in_catalog as usize;
         self.catalogs.remove(&name);
-        camera.unregister_view_frame(CooSystem::ICRS, proj);
+        camera.unregister_view_frame(CooSystem::FK5J2000, proj);
     }
 
     pub fn set_kernel_size(&mut self, camera: &CameraViewPort) {
@@ -241,7 +241,7 @@ impl Manager {
             }
         } else {
             let depth = camera.get_texture_depth().min(7);
-            let cells = camera.get_hpx_cells(depth, CooSystem::ICRS);
+            let cells = camera.get_hpx_cells(depth, CooSystem::FK5J2000);
 
             for catalog in self.catalogs.values_mut() {
                 catalog.update(&cells);

--- a/src/core/src/renderable/hips/subdivide.rs
+++ b/src/core/src/renderable/hips/subdivide.rs
@@ -12,7 +12,7 @@ fn is_too_large(cell: &HEALPixCell, camera: &CameraViewPort, projection: &Projec
         .iter()
         .filter_map(|(lon, lat)| {
             let vertex = crate::math::lonlat::radec_to_xyzw(lon.to_angle(), lat.to_angle());
-            projection.icrs_celestial_to_screen_space(&vertex, camera)
+            projection.j2000_celestial_to_screen_space(&vertex, camera)
         })
         .collect::<Vec<_>>();
 

--- a/src/core/src/renderable/image/grid.rs
+++ b/src/core/src/renderable/image/grid.rs
@@ -196,7 +196,7 @@ pub fn vertices(
             x_it.clone().map(move |(x, uvx)| {
                 let ndc = if let Some(xyz) = wcs.unproj_xyz(&ImgXY::new(x as f64, y as f64)) {
                     let xyzw = crate::coosys::apply_coo_system(
-                        CooSystem::ICRS,
+                        CooSystem::FK5J2000,
                         camera.get_coo_system(),
                         &Vector4::new(xyz.y(), xyz.z(), xyz.x(), 1.0),
                     );

--- a/src/core/src/renderable/line/mod.rs
+++ b/src/core/src/renderable/line/mod.rs
@@ -399,9 +399,9 @@ impl RasterizedLineRenderer {
                     );
                 }
                 CooSpace::LonLat => {
-                    let icrs2view = CooSystem::ICRS.to(camera.get_coo_system());
+                    let j20002view = CooSystem::FK5J2000.to(camera.get_coo_system());
                     let view2world = camera.get_m2w();
-                    let icrs2world = view2world * icrs2view;
+                    let j20002world = view2world * j20002view;
 
                     crate::shader::get_shader(
                         &self.gl,
@@ -411,7 +411,7 @@ impl RasterizedLineRenderer {
                     )?
                     .bind(&self.gl)
                     .attach_uniforms_from(camera)
-                    .attach_uniform("u_2world", &icrs2world)
+                    .attach_uniform("u_2world", &j20002world)
                     .attach_uniform("u_color", &meta.color)
                     .attach_uniform("u_width", &meta.thickness)
                     .attach_uniform("u_proj", proj)

--- a/src/core/src/renderable/moc/mod.rs
+++ b/src/core/src/renderable/moc/mod.rs
@@ -85,33 +85,6 @@ impl MOC {
         }
     }
 
-    /*pub(super) fn cell_indices_in_view(&mut self, camera: &mut CameraViewPort) {
-        for render in &mut self.inner {
-            if let Some(render) = render.as_mut() {
-                render.cell_indices_in_view(camera);
-            }
-        }
-    }*/
-
-    /*pub(super) fn num_cells_in_view(&self, camera: &mut CameraViewPort) -> usize {
-        self.inner
-            .iter()
-            .filter_map(|moc| moc.as_ref())
-            .map(|moc| moc.num_cells_in_view(camera))
-            .sum()
-    }*/
-
-    /*pub(super) fn num_vertices_in_view(&self, camera: &mut CameraViewPort) -> usize {
-        let mut num_vertices = 0;
-        for render in &self.0 {
-            if let Some(render) = render.as_ref() {
-                num_vertices += render.num_vertices_in_view(camera);
-            }
-        }
-
-        num_vertices
-    }*/
-
     pub fn set_options(&mut self, cfg: &MOCOptions, gl: WebGlContext) {
         let inner = [
             if cfg.perimeter {
@@ -178,12 +151,6 @@ impl MOC {
 }
 
 struct MOCIntern {
-    // HEALPix index vector
-    // Used for fast HEALPix cell retrieval
-    //hpx_idx_vec: IdxVec,
-
-    // Node indices in view
-    //indices: Vec<Range<usize>>,
     mode: RenderModeType,
 
     gl: WebGlContext,
@@ -256,136 +223,20 @@ impl MOCIntern {
             }
         };
 
-        /*let hpx_idx_vec =
-        IdxVec::from_hpx_cells((&moc.0).into_range_moc_iter().cells().flat_map(|cell| {
-            let cell = HEALPixCell(cell.depth, cell.idx);
-            let dd = if 3 >= cell.depth() {
-                3 - cell.depth()
-            } else {
-                0
-            };
-            cell.get_tile_cells(dd)
-        }));
-        */
         Self {
-            //nodes,
-            //moc,
-            //hpx_idx_vec,
-            //indices: vec![],
             vao,
             gl,
             mode,
         }
     }
 
-    /*fn cell_indices_in_view(&mut self, moc: &HEALPixCoverage, camera: &mut CameraViewPort) {
-        // Cache it for several reuse during the same frame
-        let view_depth = camera.get_texture_depth();
-        let cells_iter = camera.get_hpx_cells(view_depth, CooSystem::ICRS);
-
-        if moc.is_empty() {
-            self.indices = vec![0..0];
-            return;
-        }
-
-        /*let indices: Vec<_> = if view_depth > 7 {
-            // Binary search version, we are using this alternative for retrieving
-            // MOC's cells to render for deep fields of view
-            let first_cell_rng = &self.nodes[0].cell.z_29_rng();
-            let last_cell_rng = &self.nodes[self.nodes.len() - 1].cell.z_29_rng();
-
-            cells_iter
-                .filter_map(|cell| {
-                    let cell_rng = cell.z_29_rng();
-                    // Quick rejection test
-                    if cell_rng.end <= first_cell_rng.start || cell_rng.start >= last_cell_rng.end {
-                        None
-                    } else {
-                        let contains_val = |hash_z29: u64| -> Result<usize, usize> {
-                            self.nodes.binary_search_by(|node| {
-                                let node_cell_rng = node.cell.z_29_rng();
-
-                                if hash_z29 < node_cell_rng.start {
-                                    // the node cell range contains hash_z29
-                                    Ordering::Greater
-                                } else if hash_z29 >= node_cell_rng.end {
-                                    Ordering::Less
-                                } else {
-                                    Ordering::Equal
-                                }
-                            })
-                        };
-
-                        let start_idx = contains_val(cell_rng.start);
-                        let end_idx = contains_val(cell_rng.end);
-
-                        let cell_indices = match (start_idx, end_idx) {
-                            (Ok(l), Ok(r)) => {
-                                if l == r {
-                                    l..(r + 1)
-                                } else {
-                                    l..r
-                                }
-                            }
-                            (Err(l), Ok(r)) => l..r,
-                            (Ok(l), Err(r)) => l..r,
-                            (Err(l), Err(r)) => l..r,
-                        };
-
-                        Some(cell_indices)
-                    }
-                })
-                .collect()
-        } else {
-            // Index Vector 7 order version
-            cells_iter
-                .map(|cell| self.hpx_idx_vec.get_item_indices_inside_hpx_cell(&cell))
-                .collect()
-        };*/
-
-        let indices = cells_iter
-            .map(|cell| self.hpx_idx_vec.get_item_indices_inside_hpx_cell(&cell))
-            .collect();
-        let indices = crate::utils::merge_overlapping_intervals(indices);
-        self.indices = indices;
-    }*/
-
-    /*fn num_vertices_in_view(&self, camera: &CameraViewPort) -> usize {
-        self.cells_in_view(camera)
-            .filter_map(|n| n.vertices.as_ref())
-            .map(|n_vertices| {
-                n_vertices
-                    .vertices
-                    .iter()
-                    .map(|edge| edge.len())
-                    .sum::<usize>()
-            })
-            .sum()
-    }*/
-
-    /*fn num_cells_in_view(&self, _camera: &CameraViewPort) -> usize {
-        self.indices
-            .iter()
-            .map(|range| range.end - range.start)
-            .sum()
-    }*/
-
-    /*fn cells_in_view<'a>(&'a self, _camera: &CameraViewPort) -> impl Iterator<Item = Node> {
-        let nodes = &self.nodes;
-        self.indices
-            .iter()
-            .map(move |indices| nodes[indices.start..indices.end].iter())
-            .flatten()
-    }*/
-
     fn vertices_in_view<'a>(
         &self,
         moc: &'a HEALPixCoverage,
         camera: &'a mut CameraViewPort,
     ) -> impl Iterator<Item = [(f64, f64); 4]> + 'a {
-        let view_moc = camera.get_cov(CooSystem::ICRS);
-        //self.cells_in_view(camera)
-        //    .filter_map(move |node| node.vertices.as_ref())
+        let view_moc = camera.get_cov(CooSystem::FK5J2000);
+
         moc.overlapped_by_iter(view_moc)
             .cells()
             .flat_map(|cell| {
@@ -412,7 +263,7 @@ impl MOCIntern {
         match self.mode {
             RenderModeType::Perimeter { thickness, color } => {
                 let moc_in_view = moc
-                    .overlapped_by_iter(&camera.get_cov(CooSystem::ICRS))
+                    .overlapped_by_iter(&camera.get_cov(CooSystem::FK5J2000))
                     .into_range_moc();
                 let perimeter_vertices_iter = moc_in_view
                     .border_elementary_edges()
@@ -475,9 +326,9 @@ impl MOCIntern {
 
                 let num_instances = buf.len() / 4;
 
-                let icrs2view = CooSystem::ICRS.to(camera.get_coo_system());
+                let j20002view = CooSystem::FK5J2000.to(camera.get_coo_system());
                 let view2world = camera.get_m2w();
-                let icrs2world = view2world * icrs2view;
+                let j20002world = view2world * j20002view;
 
                 crate::shader::get_shader(
                     &self.gl,
@@ -487,7 +338,7 @@ impl MOCIntern {
                 )?
                 .bind(&self.gl)
                 .attach_uniforms_from(camera)
-                .attach_uniform("u_2world", &icrs2world)
+                .attach_uniform("u_2world", &j20002world)
                 .attach_uniform("u_color", &color)
                 .attach_uniform("u_width", &(camera.get_width()))
                 .attach_uniform("u_height", &(camera.get_height()))
@@ -513,9 +364,9 @@ impl MOCIntern {
 
                 let num_instances = buf.len() / 4;
 
-                let icrs2view = CooSystem::ICRS.to(camera.get_coo_system());
+                let j20002view = CooSystem::FK5J2000.to(camera.get_coo_system());
                 let view2world = camera.get_m2w();
-                let icrs2world = view2world * icrs2view;
+                let j20002world = view2world * j20002view;
 
                 crate::shader::get_shader(
                     &self.gl,
@@ -525,7 +376,7 @@ impl MOCIntern {
                 )?
                 .bind(&self.gl)
                 .attach_uniforms_from(camera)
-                .attach_uniform("u_2world", &icrs2world)
+                .attach_uniform("u_2world", &j20002world)
                 .attach_uniform("u_color", &color)
                 .attach_uniform("u_width", &(camera.get_width()))
                 .attach_uniform("u_height", &(camera.get_height()))
@@ -582,16 +433,16 @@ impl MOCIntern {
                     )
                     .update_element_array(WebGl2RenderingContext::DYNAMIC_DRAW, VecData(&indices));
 
-                let icrs2view = CooSystem::ICRS.to(camera.get_coo_system());
+                let j20002view = CooSystem::FK5J2000.to(camera.get_coo_system());
                 let view2world = camera.get_m2w();
-                let icrs2world = view2world * icrs2view;
+                let j20002world = view2world * j20002view;
                 
                 self.gl.enable(WebGl2RenderingContext::CULL_FACE);
 
                 crate::shader::get_shader(&self.gl, shaders, "moc_base.vert", "moc_base.frag")?
                     .bind(&self.gl)
                     .attach_uniforms_from(camera)
-                    .attach_uniform("u_2world", &icrs2world)
+                    .attach_uniform("u_2world", &j20002world)
                     .attach_uniform("u_color", &color)
                     .attach_uniform("u_proj", proj)
                     .bind_vertex_array_object_ref(&self.vao)
@@ -614,52 +465,6 @@ impl MOCIntern {
         moc: &'a HEALPixCoverage,
         camera: &'a mut CameraViewPort,
     ) -> impl Iterator<Item = f32> + 'a {
-        /*self.vertices_in_view(view_moc, moc, camera)
-        .filter_map(move |cell_vertices| {
-            let mut ndc: [[f32; 2]; 5] =
-                [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]];
-
-            let vertices = cell_vertices;
-
-            for i in 0..4 {
-                let line_vertices = vertices[i];
-
-                //for k in 0..line_vertices.len() {
-                let (lon, lat) = line_vertices;
-
-                let xyzw = crate::math::lonlat::radec_to_xyzw(Angle(lon), Angle(lat));
-                let xyzw =
-                    crate::coosys::apply_coo_system(CooSystem::ICRS, camera_coosys, &xyzw);
-
-                if let Some(p) = proj.model_to_normalized_device_space(&xyzw, camera) {
-                    if i > 0 && crossing_edges_testing {
-                        let mag2 = crate::math::vector::dist2(
-                            crate::math::projection::ndc_to_clip_space(&p, camera).as_ref(),
-                            crate::math::projection::ndc_to_clip_space(
-                                &Vector2::new(ndc[i - 1][0] as f64, ndc[i - 1][1] as f64),
-                                camera,
-                            )
-                            .as_ref(),
-                        );
-                        //al_core::info!("mag", i, mag2);
-                        if mag2 > 0.1 {
-                            return None;
-                        }
-                    }
-
-                    ndc[i] = [p.x as f32, p.y as f32];
-                } else {
-                    return None;
-                }
-
-                //ndc[i] = [xyzw.x as f32, xyzw.y as f32];
-                //ndc[i] = [lon as f32, lat as f32];
-            }
-
-            ndc[4] = ndc[0].clone();
-
-            Some(PathVertices { vertices: ndc })
-        })*/
         self.vertices_in_view(moc, camera)
             .map(|v| {
                 let vertices = [

--- a/src/core/src/renderable/moc/renderer.rs
+++ b/src/core/src/renderable/moc/renderer.rs
@@ -76,7 +76,7 @@ impl MOCRenderer {
             .push(MOCHierarchy::from_full_res_moc(self.gl.clone(), moc, &cfg));
         self.cfgs.push(cfg);
 
-        camera.register_view_frame(CooSystem::ICRS, proj);
+        camera.register_view_frame(CooSystem::FK5J2000, proj);
         //self.layers.push(key);
     }
 
@@ -96,7 +96,7 @@ impl MOCRenderer {
     ) -> Option<MOCOptions> {
         if let Some(idx) = self.cfgs.iter().position(|cfg| cfg.get_uuid() == moc_uuid) {
             self.mocs.remove(idx);
-            camera.unregister_view_frame(CooSystem::ICRS, proj);
+            camera.unregister_view_frame(CooSystem::FK5J2000, proj);
 
             Some(self.cfgs.remove(idx))
         } else {

--- a/src/core/src/renderable/shape/polyline.rs
+++ b/src/core/src/renderable/shape/polyline.rs
@@ -185,14 +185,14 @@ impl PolylineRenderer {
         );*/
 
         // draw the instanced lines
-        let icrs2view = CooSystem::ICRS.to(camera.get_coo_system());
+        let j20002view = CooSystem::FK5J2000.to(camera.get_coo_system());
         let view2world = camera.get_m2w();
-        let icrs2world = view2world * icrs2view;
+        let j20002world = view2world * j20002view;
 
         crate::shader::get_shader(&self.gl, shaders, "line_inst_lonlat.vert", "line_base.frag")?
             .bind(&self.gl)
             .attach_uniforms_from(camera)
-            .attach_uniform("u_2world", &icrs2world)
+            .attach_uniform("u_2world", &j20002world)
             .attach_uniform("u_color", &self.color)
             .attach_uniform("u_width", &self.thickness)
             .attach_uniform("u_proj", proj)

--- a/src/css/aladin.css
+++ b/src/css/aladin.css
@@ -1125,7 +1125,7 @@
 .aladin-location {
     position: absolute;
     top: 0.2rem;
-    left: 4.7rem;
+    left: 5.2rem;
     font-family: monospace;
 
     color: white;
@@ -1217,7 +1217,7 @@
 .aladin-projection-control {
     position: absolute;
     top: 0.2rem;
-    right: 3rem;
+    right: 2.6rem;
 }
 
 .aladin-fullscreen {

--- a/src/js/CooFrameEnum.js
+++ b/src/js/CooFrameEnum.js
@@ -30,13 +30,14 @@
 
 export let CooFrameEnum = (function() {
 
-    var systems = {J2000: 'J2000', GAL: 'GAL'};
+    // Corresponds to the Rust CooSystem enum possibilities.
+    var systems = {J2000: 'FK5J2000', GAL: 'GAL'};
     return {
         SYSTEMS: systems,
 
-        J2000: {label: "ICRS", system: systems.J2000},
-        J2000d: {label: "ICRSd", system: systems.J2000},
-        GAL:  {label: "GAL", system: systems.GAL},
+        J2000: {label: "J2000", system: systems.J2000, explain: "Equatorial (FK5 J2000)"},
+        J2000d: {label: "J2000d", system: systems.J2000, explain: "Equatorial (FK5 J2000) in decimals"},
+        GAL:  {label: "GAL", system: systems.GAL, explain: "Galactical"},
 
         fromString: function(str, defaultValue) {
             if (! str) {

--- a/src/js/DefaultHiPSList.js
+++ b/src/js/DefaultHiPSList.js
@@ -9,7 +9,7 @@ export let HiPSList = (function () {
             maxOrder: 9,
             tileSize: 512,
             imgFormat: "jpeg",
-            cooFrame: "ICRS",
+            cooFrame: "equatorial",
             startUrl: "https://alasky.cds.unistra.fr/DSS/DSSColor",
         },
         {
@@ -19,7 +19,7 @@ export let HiPSList = (function () {
             maxOrder: 9,
             tileSize: 512,
             imgFormat: "jpeg",
-            cooFrame: "ICRS",
+            cooFrame: "equatorial",
             startUrl: "https://alaskybis.cds.unistra.fr/2MASS/Color",
         },
         {
@@ -29,7 +29,7 @@ export let HiPSList = (function () {
             maxOrder: 9,
             tileSize: 512,
             imgFormat: "fits",
-            cooFrame: "ICRS",
+            cooFrame: "equatorial",
             numBitsPerPixel: 16,
             // options
             minCut: 1000.0,
@@ -46,7 +46,7 @@ export let HiPSList = (function () {
             maxOrder: 7,
             tileSize: 512,
             numBitsPerPixel: -32,
-            cooFrame: "ICRS",
+            cooFrame: "equatorial",
             minCut: 0,
             maxCut: 12000,
             stretch: "asinh",
@@ -61,7 +61,7 @@ export let HiPSList = (function () {
             maxOrder: 11,
             tileSize: 512,
             imgFormat: "fits",
-            cooFrame: "ICRS",
+            cooFrame: "equatorial",
             numBitsPerPixel: -32,
             // options
             minCut: -34,
@@ -77,7 +77,7 @@ export let HiPSList = (function () {
             maxOrder: 11,
             tileSize: 512,
             imgFormat: "jpeg",
-            cooFrame: "ICRS",
+            cooFrame: "equatorial",
             startUrl: "https://alasky.cds.unistra.fr/Pan-STARRS/DR1/color-z-zg-g",
         },
         {

--- a/src/js/MOC.js
+++ b/src/js/MOC.js
@@ -270,8 +270,8 @@ export let MOC = (function() {
      * Tests whether a given (ra, dec) point on the sky is within the current MOC object
      *
      * @memberof MOC
-     * @param {number} ra - Right-Ascension of the location in degrees and ICRS frame
-     * @param {number} dec - Declination of the location in degrees and ICRS frame
+     * @param {number} ra - Right-Ascension of the location in degrees and FK5J2000 frame
+     * @param {number} dec - Declination of the location in degrees and FK5J2000 frame
      *
      * @returns {boolean} True if the point is contained, false otherwise
      */

--- a/src/js/Overlay.js
+++ b/src/js/Overlay.js
@@ -120,9 +120,9 @@ export let GraphicOverlay = (function() {
         }
     };
 
-    // return an array of Footprint from a STC-S string
     /**
-     * Parse a STCS string and returns a list of footprints (only circles, polygons and ellipses given in ICRS frame are handled).
+     * Parse a STCS string and returns a list of footprints (only circles, polygons and ellipses given in ICRS/FK5J2000 frame are handled).
+     * For visualization purposes, the difference between FK5J2000 (ESA method) and ICRS system is not noticeable. Therefore one can be interpreted as the other. 
      *
      * @memberof GraphicOverlay
      * 

--- a/src/js/View.js
+++ b/src/js/View.js
@@ -1956,15 +1956,10 @@ export let View = (function () {
         this.cooFrame = cooFrame;
 
         // Set the new frame to the backend
-        if (this.cooFrame.system == CooFrameEnum.SYSTEMS.GAL) {
-            this.wasm.setCooSystem(Aladin.wasmLibs.core.CooSystem.GAL);
-        }
-        else if (this.cooFrame.system == CooFrameEnum.SYSTEMS.J2000) {
-            this.wasm.setCooSystem(Aladin.wasmLibs.core.CooSystem.ICRS);
-        }
+        this.wasm.setCooSystem(this.cooFrame.system);
 
         // Set the grid label format
-        if (this.cooFrame.label == "ICRS") {
+        if (this.cooFrame.label == "J2000") {
             this.setGridOptions({fmt: "sexagesimal"});
         }
         else {
@@ -2012,10 +2007,10 @@ export let View = (function () {
 
     /**
      *
-     * @API Point to a specific location in ICRS
+     * @API Point to a specific location
      *
-     * @param ra ra expressed in ICRS J2000 frame
-     * @param dec dec expressed in ICRS J2000 frame
+     * @param ra ra expressed in ICRS or FK5J2000 frame
+     * @param dec dec expressed in ICRS or FK5J2000 frame
      * @param options
      *
      */

--- a/src/js/gui/Input/CooFrame.js
+++ b/src/js/gui/Input/CooFrame.js
@@ -50,7 +50,7 @@
             },
             classList: ['aladin-cooFrame'],
             tooltip: {
-                content: "Change the frame",
+                content: cooFrame.explain,
                 position: {
                     direction: 'bottom'
                 }
@@ -71,7 +71,13 @@
             let frame = e.detail.cooFrame;
 
             self.update({
-                value: frame.label
+                value: frame.label,
+                tooltip: {
+                    content: frame.explain,
+                    position: {
+                        direction: 'bottom'
+                    }
+                },
             }, aladin);
         });
     }


### PR DESCRIPTION
The coo system handled by Aladin Lite is FK5J2000 and not ICRS. For Aladin Lite visualization purposes, the difference is not noticeable but it is better to label coo frame as they are.

This PR:
* fix the labels of the coo systems
* add a more refined GAL <-> FK5J2000 matrix transformation coming from the ESA method

