### PR TITLE
Fix MOC settings after its creation

### DIFF
--- a/examples/al-moc-json.html
+++ b/examples/al-moc-json.html
@@ -24,8 +24,14 @@
         //var json = {"3":[517],
         //"4":[2065, 2067]};        
         
-        var moc = A.MOCFromJSON(json, {opacity: 0.5, color: 'magenta', lineWidth: 1, adaptativeDisplay: false});
+        var moc = A.MOCFromJSON(json, {opacity: 0.5, color: 'magenta', lineWidth: 1, fill: true});
         aladin.addMOC(moc);
+
+        // Change the moc options after its creation
+        setTimeout(() => {
+            moc.opacity = 0.2
+            moc.fillColor = "orange"
+        }, 3000)
     });
 </script>
 </body>

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -88,4 +88,4 @@ codegen-units = 16
 rpath = false
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = true
+wasm-opt = false

--- a/src/core/al-api/src/moc.rs
+++ b/src/core/al-api/src/moc.rs
@@ -4,7 +4,7 @@ use super::color::{Color, ColorRGBA};
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
-pub struct MOC {
+pub struct MOCOptions {
     uuid: String,
     pub line_width: f32,
     pub perimeter: bool,
@@ -18,7 +18,7 @@ pub struct MOC {
 use crate::{color::ColorRGB, Abort};
 use std::convert::TryInto;
 #[wasm_bindgen]
-impl MOC {
+impl MOCOptions {
     #[wasm_bindgen(constructor)]
     pub fn new(
         uuid: String,
@@ -58,13 +58,13 @@ impl MOC {
     }
 }
 
-impl MOC {
+impl MOCOptions {
     pub fn get_uuid(&self) -> &String {
         &self.uuid
     }
 }
 
-impl Default for MOC {
+impl Default for MOCOptions {
     fn default() -> Self {
         Self {
             uuid: String::from("moc"),

--- a/src/core/src/app.rs
+++ b/src/core/src/app.rs
@@ -20,6 +20,7 @@ use crate::{
     tile_fetcher::TileFetcherQueue,
     time::DeltaTime,
 };
+use al_api::moc::MOCOptions;
 use crate::math::angle::ToAngle;
 use al_core::image::format::ChannelType;
 use wcs::WCS;
@@ -477,25 +478,25 @@ impl App {
         self.catalog_loaded
     }
 
-    pub(crate) fn get_moc(&self, cfg: &al_api::moc::MOC) -> Option<&HEALPixCoverage> {
-        self.moc.get_hpx_coverage(cfg)
+    pub(crate) fn get_moc(&self, moc_uuid: &str) -> Option<&HEALPixCoverage> {
+        self.moc.get_hpx_coverage(moc_uuid)
     }
 
     pub(crate) fn add_moc(
         &mut self,
-        cfg: al_api::moc::MOC,
         moc: HEALPixCoverage,
+        options: MOCOptions,
     ) -> Result<(), JsValue> {
         self.moc
-            .push_back(moc, cfg, &mut self.camera, &self.projection);
+            .push_back(moc, options, &mut self.camera, &self.projection);
         self.request_redraw = true;
 
         Ok(())
     }
 
-    pub(crate) fn remove_moc(&mut self, cfg: &al_api::moc::MOC) -> Result<(), JsValue> {
+    pub(crate) fn remove_moc(&mut self, moc_uuid: &str) -> Result<(), JsValue> {
         self.moc
-            .remove(cfg, &mut self.camera, &self.projection)
+            .remove(moc_uuid, &mut self.camera, &self.projection)
             .ok_or_else(|| JsValue::from_str("MOC not found"))?;
 
         self.request_redraw = true;
@@ -503,9 +504,9 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn set_moc_cfg(&mut self, cfg: al_api::moc::MOC) -> Result<(), JsValue> {
+    pub(crate) fn set_moc_options(&mut self, options: MOCOptions) -> Result<(), JsValue> {
         self.moc
-            .set_cfg(cfg, &mut self.camera, &self.projection, &mut self.shaders)
+            .set_options(options, &mut self.camera, &self.projection, &mut self.shaders)
             .ok_or_else(|| JsValue::from_str("MOC not found"))?;
         self.request_redraw = true;
 

--- a/src/core/src/downloader/query.rs
+++ b/src/core/src/downloader/query.rs
@@ -176,16 +176,16 @@ impl Query for PixelMetadata {
         &self.id
     }
 }
-
+use al_api::moc::MOCOptions;
 /* ---------------------------------- */
 pub struct Moc {
     // The total url of the query
     pub url: Url,
-    pub params: al_api::moc::MOC,
+    pub params: MOCOptions,
     pub hips_cdid: CreatorDid,
 }
 impl Moc {
-    pub fn new(url: String, hips_cdid: CreatorDid, params: al_api::moc::MOC) -> Self {
+    pub fn new(url: String, hips_cdid: CreatorDid, params: MOCOptions) -> Self {
         Moc {
             url,
             params,

--- a/src/core/src/downloader/request/moc.rs
+++ b/src/core/src/downloader/request/moc.rs
@@ -10,7 +10,7 @@ use moclib::qty::Hpx;
 pub struct MOCRequest {
     //pub id: QueryId,
     pub hips_cdid: CreatorDid,
-    pub params: al_api::moc::MOC,
+    pub params: MOCOptions,
     request: Request<HEALPixCoverage>,
 }
 
@@ -41,6 +41,7 @@ pub fn from_fits_hpx<T: Idx>(moc: MocType<T, Hpx<T>, Cursor<&[u8]>>) -> Smoc {
 
 use crate::healpix::coverage::HEALPixCoverage;
 use crate::Abort;
+use al_api::moc::MOCOptions;
 use moclib::deser::fits::MocIdxType;
 use moclib::deser::fits::MocQtyType;
 use moclib::idx::Idx;
@@ -106,7 +107,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 pub struct Moc {
     pub moc: Rc<RefCell<Option<HEALPixCoverage>>>,
-    pub params: al_api::moc::MOC,
+    pub params: MOCOptions,
     pub hips_cdid: Url,
 }
 

--- a/src/core/src/renderable/moc/hierarchy.rs
+++ b/src/core/src/renderable/moc/hierarchy.rs
@@ -1,26 +1,34 @@
 use super::MOC;
 use crate::{camera::CameraViewPort, HEALPixCoverage};
-use al_api::moc::MOC as Cfg;
+use al_api::moc::MOCOptions;
 
 pub struct MOCHierarchy {
     full_res_depth: u8,
     // MOC at different resolution
     mocs: Vec<MOC>,
+    gl: WebGlContext,
 }
 use al_core::WebGlContext;
 impl MOCHierarchy {
-    pub fn from_full_res_moc(gl: WebGlContext, full_res_moc: HEALPixCoverage, cfg: &Cfg) -> Self {
+    pub fn from_full_res_moc(gl: WebGlContext, full_res_moc: HEALPixCoverage, options: &MOCOptions) -> Self {
         let full_res_depth = full_res_moc.depth();
 
         let mut mocs: Vec<_> = (0..full_res_depth)
-            .map(|d| MOC::new(gl.clone(), HEALPixCoverage(full_res_moc.degraded(d)), cfg))
+            .map(|d| MOC::new(gl.clone(), HEALPixCoverage(full_res_moc.degraded(d)), options))
             .collect();
 
-        mocs.push(MOC::new(gl, full_res_moc, cfg));
+        mocs.push(MOC::new(gl.clone(), full_res_moc, options));
 
         Self {
             mocs,
             full_res_depth,
+            gl,
+        }
+    }
+
+    pub fn set_options(&mut self, options: &MOCOptions) {
+        for moc in &mut self.mocs {
+            moc.set_options(&options, self.gl.clone());
         }
     }
 

--- a/src/core/src/tile_fetcher.rs
+++ b/src/core/src/tile_fetcher.rs
@@ -5,6 +5,7 @@ use crate::Abort;
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
+use al_api::moc::MOCOptions;
 
 const MAX_NUM_TILE_FETCHING: usize = 8;
 const MAX_QUERY_QUEUE_LENGTH: usize = 100;
@@ -208,7 +209,7 @@ impl TileFetcherQueue {
         downloader.borrow_mut().fetch(query::Moc::new(
             moc_url,
             cfg.get_creator_did().to_string(),
-            al_api::moc::MOC::default(),
+            MOCOptions::default(),
         ));
 
         let tile_size = cfg.get_tile_size();


### PR DESCRIPTION
MOC settings after their creation was not possible. This PR fix it.

It is also possible to directly set the `color`, `fillColor`, `opacity` and `lineWidth` MOC properties without doing any reportChange afterwards. These settings will automatically notify the wasm part for change of the MOC options and will update the view.