### PR TITLE
fix: GraphicOverlay's footprints selection restored

### DIFF
--- a/examples/al-footprints.html
+++ b/examples/al-footprints.html
@@ -13,7 +13,7 @@
         // Start up Aladin Lite
         aladin = A.aladin('#aladin-lite-div', {survey: "CDS/P/DSS2/color", target: 'M 1', fov: 0.2, showContextMenu: true, fullScreen: true});
         var overlay = A.graphicOverlay({color: '#ee2345', lineWidth: 3, lineDash: [2, 2]});
-        /*aladin.addOverlay(overlay);
+        aladin.addOverlay(overlay);
         overlay.addFootprints([
             A.polygon([[83.64287, 22.01713], [83.59872, 22.01692], [83.59852, 21.97629], [83.64295, 21.97629]], {hoverColor: 'green'}),
             A.polygon([[83.62807, 22.06330], [83.58397, 22.02280], [83.62792, 22.02258]]),
@@ -21,7 +21,7 @@
         ]);
         overlay.add(A.circle(83.66067, 22.03081, 0.04, {color: 'cyan'})); // radius in degrees
         overlay.add(A.vector(83.66067, 22.03081, 0.04, {color: 'cyan'})); // radius in degrees
-        */
+        
         aladin.on("footprintClicked", (footprint, xyMouseCoords) => {
             console.log("footprint clicked catched: ", footprint, "mouse coords xy: ", xyMouseCoords.x, xyMouseCoords.y);
         })
@@ -35,8 +35,8 @@
             console.log("Object hovered stopped: ", object, "mouse coords xy: ", xyMouseCoords.x, xyMouseCoords.y);
         })
 
-        const cat = A.catalogFromVizieR('B/assocdata/obscore', 'M 1', 10, {onClick: 'showTable', selectionColor: "orange", hoverColor: 'red', limit: 10000});
-        aladin.addCatalog(cat);
+        //const cat = A.catalogFromVizieR('B/assocdata/obscore', 'M 1', 10, {onClick: 'showTable', selectionColor: "orange", hoverColor: 'red', limit: 10000});
+        //aladin.addCatalog(cat);
     });
 </script>
 </body>

--- a/src/js/Catalog.js
+++ b/src/js/Catalog.js
@@ -613,7 +613,6 @@ export let Catalog = (function () {
                                 // Set the same color of the shape than the catalog. 
                                 // FIXME: the color/shape could be a parameter at the source level, allowing the user single catalogs handling different shapes
                                 shape.setColor(this.color)
-
                                 shape.setSelectionColor(this.selectionColor);
                                 shape.setHoverColor(this.hoverColor);
                             }

--- a/src/js/View.js
+++ b/src/js/View.js
@@ -630,6 +630,7 @@ export let View = (function () {
                 var footprintClickedFunction = view.aladin.callbacksByEventName['footprintClicked'];
 
                 let objsByCats = {};
+                let footprints = [];
                 for (let o of objs) {
                     // classify the different objects by catalog
                     let cat = o.getCatalog && o.getCatalog();
@@ -647,12 +648,22 @@ export let View = (function () {
                         if (typeof footprintClickedFunction === 'function') {
                             footprintClickedFunction(o, xy);
                         }
+                        // If this footprint has a catalog then it will be selected from its source
+                        // so we will not add it
+                        if (!cat) {
+                            footprints.push(o);
+                        } 
                     }
                 }
 
-                // rewrite objs
+                // Rewrite objs
                 objs = Array.from(Object.values(objsByCats));
+                // Add the external footprints (i.e. which are not associated with catalog sources e.g. those from GraphicOverlay)
+                if (footprints.length > 0) {
+                    objs.push(footprints)
+                }
                 view.selectObjects(objs);
+
                 view.lastClickedObject = objs;
                 
             } else {
@@ -2160,26 +2171,21 @@ export let View = (function () {
         }
 
         let closests = [];
-        const fLineWidth = (footprints && footprints[0] && footprints[0].getLineWidth()) || 1;
-        let lw = fLineWidth + 3;
-        //for (var lw = startLw + 1; lw <= startLw + 3; lw++) {
-            footprints.forEach((footprint) => {
-                if (!footprint.source || !footprint.source.tooSmallFootprint) {
-                    // Hidden footprints are not considered
-                    //let originLineWidth = footprint.getLineWidth();
-    
-                    footprint.setLineWidth(lw);
-                    if (footprint.isShowing && footprint.isInStroke(ctx, this, x * window.devicePixelRatio, y * window.devicePixelRatio)) {
-                        closests.push(footprint);
-                    }
-                    footprint.setLineWidth(fLineWidth);
-                }
-            })
 
-        /*    if (closests.length > 0) {
-                break;
+        footprints.forEach((footprint) => {
+            if (!footprint.source || !footprint.source.tooSmallFootprint) {
+                const originLineWidth = footprint.getLineWidth();
+                let spreadedLineWidth = (originLineWidth || 1) + 3;
+
+                footprint.setLineWidth(spreadedLineWidth);
+                if (footprint.isShowing && footprint.isInStroke(ctx, this, x * window.devicePixelRatio, y * window.devicePixelRatio)) {
+                    closests.push(footprint);
+                }
+
+                footprint.setLineWidth(originLineWidth);
             }
-        }*/
+        })
+
 
         return closests;
     };
@@ -2191,13 +2197,11 @@ export let View = (function () {
         var canvas = this.catalogCanvas;
         var ctx = canvas.getContext("2d");
         // this makes footprint selection easier as the catch-zone is larger
-        //let pastLineWidth = ctx.lineWidth;
 
         let closests = [];
         if (this.overlays) {
             for (var k = 0; k < this.overlays.length; k++) {
                 overlay = this.overlays[k];
-
                 closests = closests.concat(this.closestFootprints(overlay.overlayItems, ctx, x, y));
             }
         }

--- a/src/js/shapes/Circle.js
+++ b/src/js/shapes/Circle.js
@@ -48,7 +48,7 @@ export let Circle = (function() {
 
         this.color     = options['color']     || undefined;
         this.fillColor = options['fillColor'] || undefined;
-        this.lineWidth = options["lineWidth"] || 2;
+        this.lineWidth = options["lineWidth"] || undefined;
         this.selectionColor = options["selectionColor"] || '#00ff00';
         this.hoverColor = options["hoverColor"] || undefined;
         this.opacity    = options['opacity']   || 1;
@@ -295,6 +295,10 @@ export let Circle = (function() {
             ctx.strokeStyle = this.hoverColor || GraphicOverlay.increaseBrightness(baseColor, 25);
         } else {
             ctx.strokeStyle = baseColor;
+        }
+
+        if (!this.lineWidth) {
+            this.lineWidth = (this.overlay && this.overlay.lineWidth) || 2;
         }
 
         ctx.lineWidth = this.lineWidth;

--- a/src/js/shapes/Ellipse.js
+++ b/src/js/shapes/Ellipse.js
@@ -51,7 +51,7 @@ export let Ellipse = (function() {
 
         this.color = options['color'] || undefined;
         this.fillColor = options['fillColor'] || undefined;
-        this.lineWidth = options["lineWidth"] || 2;
+        this.lineWidth = options["lineWidth"] || undefined;
         this.selectionColor = options["selectionColor"] || '#00ff00';
         this.hoverColor = options["hoverColor"] || undefined;
         this.opacity   = options['opacity']   || 1;
@@ -281,6 +281,10 @@ export let Ellipse = (function() {
             ctx.strokeStyle = this.hoverColor || GraphicOverlay.increaseBrightness(baseColor, 25);
         } else {
             ctx.strokeStyle = baseColor;
+        }
+
+        if (!this.lineWidth) {
+            this.lineWidth = (this.overlay && this.overlay.lineWidth) || 2;
         }
 
         ctx.lineWidth = this.lineWidth;


### PR DESCRIPTION
Targets https://github.com/cds-astro/aladin-lite/issues/274

This is minor bug fix that can be merged for 3.6.x. It contains several fixes:

* fix in View.handleSelect. It now calls selectObjects with not only the list of sources but also with the footprints associated to GraphicOverlay objects.
* fix in View.closestFootprints. If no lineWidth was given to a footprint then it could happen that this method set it to 1px, erasing its previous undefined value
* fix: Circle and Ellipse now behaves like PolyLine and Vector, if no linewidth is given, the one from its GraphicOverlay is taken.





