### PR TITLE
Allow setting HiPS CORS and credential options

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -65,7 +65,7 @@ path = "./al-api"
 
 [dependencies.web-sys]
 version = "0.3.56"
-features = [ "console", "CssStyleDeclaration", "Document", "Element", "HtmlCollection", "HtmlElement", "HtmlImageElement", "HtmlCanvasElement", "Blob", "ImageBitmap", "ImageData", "CanvasRenderingContext2d", "WebGlBuffer", "WebGlContextAttributes", "WebGlFramebuffer", "WebGlProgram", "WebGlShader", "WebGlUniformLocation", "WebGlTexture", "WebGlActiveInfo", "Headers", "Window", "Request", "RequestInit", "RequestMode", "Response", "XmlHttpRequest", "XmlHttpRequestResponseType", "PerformanceTiming", "Performance", "Url", "ReadableStream", "File", "FileList",]
+features = [ "console", "CssStyleDeclaration", "Document", "Element", "HtmlCollection", "HtmlElement", "HtmlImageElement", "HtmlCanvasElement", "Blob", "ImageBitmap", "ImageData", "CanvasRenderingContext2d", "WebGlBuffer", "WebGlContextAttributes", "WebGlFramebuffer", "WebGlProgram", "WebGlShader", "WebGlUniformLocation", "WebGlTexture", "WebGlActiveInfo", "Headers", "Window", "Request", "RequestInit", "RequestMode", "RequestCredentials", "Response", "XmlHttpRequest", "XmlHttpRequestResponseType", "PerformanceTiming", "Performance", "Url", "ReadableStream", "File", "FileList",]
 
 [dev-dependencies.image-decoder]
 package = "image"

--- a/src/core/al-api/src/hips.rs
+++ b/src/core/al-api/src/hips.rs
@@ -57,6 +57,9 @@ pub struct HiPSProperties {
     max_cutout: Option<f32>,
 
     creator_did: String,
+
+    request_credentials: String,
+    request_mode: String,
 }
 
 impl HiPSProperties {
@@ -123,6 +126,16 @@ impl HiPSProperties {
     #[inline(always)]
     pub fn get_initial_dec(&self) -> Option<f64> {
         self.hips_initial_dec
+    }
+
+    #[inline(always)]
+    pub fn get_request_credentials(&self) -> &str {
+        &self.request_credentials
+    }
+
+    #[inline(always)]
+    pub fn get_request_mode(&self) -> &str {
+        &self.request_mode
     }
 }
 

--- a/src/core/src/downloader/query.rs
+++ b/src/core/src/downloader/query.rs
@@ -194,15 +194,25 @@ use al_api::moc::MOCOptions;
 pub struct Moc {
     // The total url of the query
     pub url: Url,
+    pub mode: RequestMode,
+    pub credentials: RequestCredentials,
     pub params: MOCOptions,
     pub hips_cdid: CreatorDid,
 }
 impl Moc {
-    pub fn new(url: String, hips_cdid: CreatorDid, params: MOCOptions) -> Self {
+    pub fn new(
+        url: String,
+        mode: RequestMode,
+        credentials: RequestCredentials,
+        hips_cdid: CreatorDid,
+        params: MOCOptions,
+    ) -> Self {
         Moc {
             url,
             params,
             hips_cdid,
+            mode,
+            credentials,
         }
     }
 }

--- a/src/core/src/downloader/query.rs
+++ b/src/core/src/downloader/query.rs
@@ -11,7 +11,7 @@ pub type QueryId = String;
 
 use al_core::image::format::ImageFormatType;
 
-#[derive(Eq, Hash, PartialEq, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub struct Tile {
     pub cell: HEALPixCell,
     pub format: ImageFormatType,
@@ -19,6 +19,8 @@ pub struct Tile {
     pub hips_cdid: CreatorDid,
     // The total url of the query
     pub url: Url,
+    pub credentials: RequestCredentials,
+    pub mode: RequestMode,
     pub id: QueryId,
     pub channel: Option<u32>,
 }
@@ -26,11 +28,14 @@ pub struct Tile {
 use crate::healpix::cell::HEALPixCell;
 use crate::renderable::hips::config::HiPSConfig;
 use crate::renderable::CreatorDid;
+use web_sys::{RequestCredentials, RequestMode};
 impl Tile {
     pub fn new(cell: &HEALPixCell, channel: Option<u32>, cfg: &HiPSConfig) -> Self {
         let hips_cdid = cfg.get_creator_did();
         let hips_url = cfg.get_root_url();
         let format = cfg.get_format();
+        let credentials = cfg.get_request_credentials();
+        let mode = cfg.get_request_mode();
 
         let ext = format.get_ext_file();
 
@@ -64,6 +69,8 @@ impl Tile {
             url,
             cell: *cell,
             format,
+            credentials,
+            mode,
             id,
             channel,
         }
@@ -89,6 +96,8 @@ pub struct Allsky {
     pub hips_cdid: CreatorDid,
     // The total url of the query
     pub url: Url,
+    pub credentials: RequestCredentials,
+    pub mode: RequestMode,
     pub id: QueryId,
 }
 
@@ -99,6 +108,8 @@ impl Allsky {
         let texture_size = cfg.get_texture_size();
         let format = cfg.get_format();
         let ext = format.get_ext_file();
+        let credentials = cfg.get_request_credentials();
+        let mode = cfg.get_request_mode();
 
         let mut url = format!("{}/Norder3/Allsky", cfg.get_root_url());
 
@@ -126,7 +137,9 @@ impl Allsky {
             url,
             format,
             id,
-            channel,
+            credentials,
+            mode,
+            channel
         }
     }
 }

--- a/src/core/src/downloader/request/allsky.rs
+++ b/src/core/src/downloader/request/allsky.rs
@@ -81,6 +81,8 @@ impl From<query::Allsky> for AllskyRequest {
             hips_cdid,
             texture_size,
             id,
+            credentials,
+            mode,
             channel: slice,
         } = query;
 
@@ -132,7 +134,8 @@ impl From<query::Allsky> for AllskyRequest {
                 _ => {
                     let mut opts = RequestInit::new();
                     opts.method("GET");
-                    opts.mode(RequestMode::Cors);
+                    opts.mode(mode);
+                    opts.credentials(credentials);
                     let window = web_sys::window().unwrap_abort();
 
                     let request = web_sys::Request::new_with_str_and_init(&url_clone, &opts)?;

--- a/src/core/src/downloader/request/allsky.rs
+++ b/src/core/src/downloader/request/allsky.rs
@@ -28,19 +28,25 @@ impl From<AllskyRequest> for RequestType {
 use super::Url;
 
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{RequestInit, RequestMode, Response};
+use web_sys::{RequestInit, Response, RequestCredentials};
 
 use al_core::{image::raw::ImageBuffer, texture::pixel::Pixel};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 
-async fn query_image(url: &str) -> Result<ImageBuffer<RGBA8U>, JsValue> {
+async fn query_image(url: &str, credentials: RequestCredentials) -> Result<ImageBuffer<RGBA8U>, JsValue> {
     let image = web_sys::HtmlImageElement::new().unwrap_abort();
     let image_cloned = image.clone();
 
+    let cors_value = match credentials {
+        RequestCredentials::Include => Some("use-credentials"),
+        RequestCredentials::SameOrigin => Some("anonymous"),
+        _ => Some("")
+    };
+
     let html_img_elt_promise = js_sys::Promise::new(
         &mut (Box::new(move |resolve, reject| {
-            image_cloned.set_cross_origin(Some(""));
+            image_cloned.set_cross_origin(cors_value);
             image_cloned.set_onload(Some(&resolve));
             image_cloned.set_onerror(Some(&reject));
             image_cloned.set_src(&url);
@@ -94,7 +100,7 @@ impl From<query::Allsky> for AllskyRequest {
             match channel {
                 ChannelType::RGB8U => {
                     let allsky_tile_size = std::cmp::min(tile_size, 64);
-                    let allsky = query_image(&url_clone).await?;
+                    let allsky = query_image(&url_clone, credentials).await?;
 
                     let allsky_tiles = handle_allsky_file::<RGBA8U>(
                         allsky,
@@ -121,7 +127,7 @@ impl From<query::Allsky> for AllskyRequest {
                 }
                 ChannelType::RGBA8U => {
                     let allsky_tile_size = std::cmp::min(tile_size, 64);
-                    let allsky = query_image(&url_clone).await?;
+                    let allsky = query_image(&url_clone, credentials).await?;
 
                     let allsky_tiles =
                         handle_allsky_file(allsky, allsky_tile_size, texture_size, tile_size)?

--- a/src/core/src/downloader/request/moc.rs
+++ b/src/core/src/downloader/request/moc.rs
@@ -24,7 +24,7 @@ use super::Url;
 use moclib::deser::fits;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{RequestInit, RequestMode, Response};
+use web_sys::{RequestInit, Response};
 
 use moclib::moc::range::op::convert::convert_to_u64;
 
@@ -55,6 +55,8 @@ impl From<query::Moc> for MOCRequest {
             url,
             params,
             hips_cdid,
+            credentials,
+            mode
         } = query;
 
         let url_clone = url.clone();
@@ -63,7 +65,8 @@ impl From<query::Moc> for MOCRequest {
         let request = Request::new(async move {
             let mut opts = RequestInit::new();
             opts.method("GET");
-            opts.mode(RequestMode::Cors);
+            opts.mode(mode);
+            opts.credentials(credentials);
 
             let request = web_sys::Request::new_with_str_and_init(&url_clone, &opts).unwrap_abort();
             let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;

--- a/src/core/src/downloader/request/tile.rs
+++ b/src/core/src/downloader/request/tile.rs
@@ -17,6 +17,8 @@ pub struct TileRequest {
     hips_cdid: CreatorDid,
     url: Url,
     format: ImageFormatType,
+    credentials: RequestCredentials,
+    mode: RequestMode,
     channel: Option<u32>,
 }
 
@@ -26,14 +28,20 @@ impl From<TileRequest> for RequestType {
     }
 }
 
-async fn query_html_image(url: &str) -> Result<web_sys::HtmlImageElement, JsValue> {
+async fn query_html_image(url: &str, credentials: RequestCredentials) -> Result<web_sys::HtmlImageElement, JsValue> {
     let image = web_sys::HtmlImageElement::new().unwrap_abort();
     let image_cloned = image.clone();
+
+    // Set the CORS and credentials options for the image
+    let cors_value = match credentials {
+        RequestCredentials::Include => Some("use-credentials"),
+        _ => Some("")
+    };
 
     let promise = js_sys::Promise::new(
         &mut (Box::new(move |resolve, reject| {
             // Ask for CORS permissions
-            image_cloned.set_cross_origin(Some(""));
+            image_cloned.set_cross_origin(cors_value);
             image_cloned.set_onload(Some(&resolve));
             image_cloned.set_onerror(Some(&reject));
             image_cloned.set_src(&url);
@@ -49,7 +57,7 @@ use al_core::image::html::HTMLImage;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{RequestInit, RequestMode, Response};
+use web_sys::{RequestInit, RequestMode, Response, RequestCredentials};
 impl From<query::Tile> for TileRequest {
     // Create a tile request associated to a HiPS
     fn from(query: query::Tile) -> Self {
@@ -58,6 +66,8 @@ impl From<query::Tile> for TileRequest {
             cell,
             url,
             hips_cdid,
+            credentials,
+            mode,
             id,
             channel: slice,
         } = query;
@@ -96,7 +106,7 @@ impl From<query::Tile> for TileRequest {
                 Ok(ImageType::RawRgb8u { image })
                 */
                 // HTMLImageElement
-                let image = query_html_image(&url_clone).await?;
+                let image = query_html_image(&url_clone, credentials).await?;
                 // The image has been resolved
                 Ok(ImageType::HTMLImageRgb8u {
                     image: HTMLImage::<RGB8U>::new(image),
@@ -131,7 +141,7 @@ impl From<query::Tile> for TileRequest {
                 Ok(ImageType::RawRgba8u { image })
                 */
                 // HTMLImageElement
-                let image = query_html_image(&url_clone).await?;
+                let image = query_html_image(&url_clone, credentials).await?;
                 // The image has been resolved
                 Ok(ImageType::HTMLImageRgba8u {
                     image: HTMLImage::<RGBA8U>::new(image),
@@ -144,7 +154,8 @@ impl From<query::Tile> for TileRequest {
             | ChannelType::R8UI => Request::new(async move {
                 let mut opts = RequestInit::new();
                 opts.method("GET");
-                opts.mode(RequestMode::Cors);
+                opts.mode(mode);
+                opts.credentials(credentials);
 
                 let request =
                     web_sys::Request::new_with_str_and_init(&url_clone, &opts).unwrap_abort();
@@ -179,6 +190,8 @@ impl From<query::Tile> for TileRequest {
             format,
             id,
             hips_cdid,
+            credentials,
+            mode,
             url,
             request,
             channel: slice,
@@ -197,6 +210,8 @@ pub struct Tile {
     pub channel: Option<u32>,
     hips_cdid: CreatorDid,
     url: Url,
+    credentials: RequestCredentials,
+    mode: RequestMode,
 }
 
 use crate::Abort;
@@ -230,6 +245,8 @@ impl<'a> From<&'a TileRequest> for Option<Tile> {
             hips_cdid,
             url,
             format,
+            credentials,
+            mode,
             channel,
             ..
         } = request;
@@ -245,6 +262,8 @@ impl<'a> From<&'a TileRequest> for Option<Tile> {
                 hips_cdid: hips_cdid.clone(),
                 url: url.clone(),
                 format: *format,
+                credentials: *credentials,
+                mode: *mode,
                 channel: *channel,
             })
         } else {

--- a/src/core/src/downloader/request/tile.rs
+++ b/src/core/src/downloader/request/tile.rs
@@ -17,8 +17,6 @@ pub struct TileRequest {
     hips_cdid: CreatorDid,
     url: Url,
     format: ImageFormatType,
-    credentials: RequestCredentials,
-    mode: RequestMode,
     channel: Option<u32>,
 }
 
@@ -35,6 +33,7 @@ async fn query_html_image(url: &str, credentials: RequestCredentials) -> Result<
     // Set the CORS and credentials options for the image
     let cors_value = match credentials {
         RequestCredentials::Include => Some("use-credentials"),
+        RequestCredentials::SameOrigin => Some("anonymous"),
         _ => Some("")
     };
 
@@ -57,7 +56,7 @@ use al_core::image::html::HTMLImage;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{RequestInit, RequestMode, Response, RequestCredentials};
+use web_sys::{RequestInit, Response, RequestCredentials};
 impl From<query::Tile> for TileRequest {
     // Create a tile request associated to a HiPS
     fn from(query: query::Tile) -> Self {
@@ -190,8 +189,6 @@ impl From<query::Tile> for TileRequest {
             format,
             id,
             hips_cdid,
-            credentials,
-            mode,
             url,
             request,
             channel: slice,
@@ -210,8 +207,6 @@ pub struct Tile {
     pub channel: Option<u32>,
     hips_cdid: CreatorDid,
     url: Url,
-    credentials: RequestCredentials,
-    mode: RequestMode,
 }
 
 use crate::Abort;
@@ -245,8 +240,6 @@ impl<'a> From<&'a TileRequest> for Option<Tile> {
             hips_cdid,
             url,
             format,
-            credentials,
-            mode,
             channel,
             ..
         } = request;
@@ -262,8 +255,6 @@ impl<'a> From<&'a TileRequest> for Option<Tile> {
                 hips_cdid: hips_cdid.clone(),
                 url: url.clone(),
                 format: *format,
-                credentials: *credentials,
-                mode: *mode,
                 channel: *channel,
             })
         } else {

--- a/src/core/src/renderable/hips/config.rs
+++ b/src/core/src/renderable/hips/config.rs
@@ -191,7 +191,6 @@ impl HiPSConfig {
             "cors" => RequestMode::Cors,
             "no-cors" => RequestMode::NoCors,
             "same-origin" => RequestMode::SameOrigin,
-            "navigate" => RequestMode::Navigate,
             _ => RequestMode::Cors,
         };
 

--- a/src/core/src/renderable/hips/config.rs
+++ b/src/core/src/renderable/hips/config.rs
@@ -1,6 +1,8 @@
 use al_api::hips::ImageExt;
 
 use al_core::image::format::{ChannelType, ImageFormatType};
+use web_sys::{RequestCredentials, RequestMode};
+
 #[derive(Debug)]
 pub struct HiPSConfig {
     pub root_url: String,
@@ -45,6 +47,9 @@ pub struct HiPSConfig {
     //dataproduct_subtype: Option<Vec<String>>,
     //colored: bool,
     pub creator_did: String,
+
+    pub request_credentials: RequestCredentials,
+    pub request_mode: RequestMode,
 }
 
 use crate::math;
@@ -174,6 +179,22 @@ impl HiPSConfig {
         } else {
             0
         };
+
+        let request_credentials = match properties.get_request_credentials() {
+            "include" => RequestCredentials::Include,
+            "same-origin" => RequestCredentials::SameOrigin,
+            "omit" => RequestCredentials::Omit,
+            _ => RequestCredentials::Omit,
+        };
+
+        let request_mode = match properties.get_request_mode() {
+            "cors" => RequestMode::Cors,
+            "no-cors" => RequestMode::NoCors,
+            "same-origin" => RequestMode::SameOrigin,
+            "navigate" => RequestMode::Navigate,
+            _ => RequestMode::Cors,
+        };
+
         let hips_config = HiPSConfig {
             creator_did,
             // HiPS name
@@ -210,6 +231,8 @@ impl HiPSConfig {
             bitpix,
             format,
             tile_size,
+            request_credentials,
+            request_mode
         };
 
         Ok(hips_config)
@@ -367,6 +390,17 @@ impl HiPSConfig {
     #[inline(always)]
     pub fn is_colored(&self) -> bool {
         self.format.is_colored()
+    }
+
+
+    #[inline(always)]
+    pub fn get_request_credentials(&self) -> RequestCredentials {
+        self.request_credentials
+    }
+
+    #[inline(always)]
+    pub fn get_request_mode(&self) -> RequestMode {
+        self.request_mode
     }
 }
 

--- a/src/core/src/tile_fetcher.rs
+++ b/src/core/src/tile_fetcher.rs
@@ -208,6 +208,8 @@ impl TileFetcherQueue {
 
         downloader.borrow_mut().fetch(query::Moc::new(
             moc_url,
+            cfg.get_request_mode(),
+            cfg.get_request_credentials(),
             cfg.get_creator_did().to_string(),
             MOCOptions::default(),
         ));

--- a/src/js/HiPS.js
+++ b/src/js/HiPS.js
@@ -166,6 +166,14 @@ PropertyParser.isPlanetaryBody = function (properties) {
  * @property {number} [saturation=0.0] - The saturation value for the color configuration.
  * @property {number} [brightness=0.0] - The brightness value for the color configuration.
  * @property {number} [contrast=0.0] - The contrast value for the color configuration.
+ * @property {string} [requestMode='cors'] - Determines how the request will interact with cross-origin resources.
+    *  - 'cors' - allow cross-origin requests with proper CORS headers.
+    *  - 'no-cors' - send the request without CORS.
+    *  - 'same-origin' - only allow requests to the same origin.
+ * @property {string} [requestCredentials='omit'] - Specifies whether to send cookies and HTTP credentials with the request.
+    *  - 'omit' - never send credentials.
+    *  - 'same-origin' - send only for same-origin requests.
+    *  - 'include' - always send, even for cross-origin requests.
  */
 
 /**
@@ -210,8 +218,8 @@ export let HiPS = (function () {
         this.options = options;
         this.name = (options && options.name) || id;
         this.startUrl = options.startUrl;
-        this.requestMode = options && options.requestMode;
-        this.requestCredentials = options && options.requestCredentials;
+        this.requestMode = options && options.requestMode || 'cors';
+        this.requestCredentials = options && options.requestCredentials || 'omit';
 
         this.slice = 0;
 
@@ -904,8 +912,8 @@ export let HiPS = (function () {
                 hipsCubeDepth: self.cubeDepth,
                 isPlanetaryBody: self.isPlanetaryBody(),
                 hipsBody: self.hipsBody,
-                requestCredentials: self.requestCredentials || 'omit',
-                requestMode: self.requestMode || 'cors',
+                requestCredentials: self.requestCredentials,
+                requestMode: self.requestMode,
             },
             meta: {
                 ...this.colorCfg.get(),

--- a/src/js/HiPS.js
+++ b/src/js/HiPS.js
@@ -210,6 +210,8 @@ export let HiPS = (function () {
         this.options = options;
         this.name = (options && options.name) || id;
         this.startUrl = options.startUrl;
+        this.requestMode = options && options.requestMode;
+        this.requestCredentials = options && options.requestCredentials;
 
         this.slice = 0;
 
@@ -314,7 +316,7 @@ export let HiPS = (function () {
                     // ID typed url
                     if (self.startUrl && isID) {
                         // First download the properties from the start url
-                        await HiPSProperties.fetchFromUrl(self.startUrl)
+                        await HiPSProperties.fetchFromUrl(self.startUrl, self.requestMode, self.requestCredentials)
                             .then((p) => {
                                 self._parseProperties(p);
                             })
@@ -363,7 +365,7 @@ export let HiPS = (function () {
                                     .catch((_) => reject("HiPS " + self.id + " error: " + id + " does not refer to a found CDS ID nor a local path pointing towards a HiPS"))
                             })
                     } else {
-                        await HiPSProperties.fetchFromUrl(self.url)
+                        await HiPSProperties.fetchFromUrl(self.url, self.requestMode, self.requestCredentials)
                             .then((p) => {
                                 self._parseProperties(p);
                             })
@@ -902,6 +904,8 @@ export let HiPS = (function () {
                 hipsCubeDepth: self.cubeDepth,
                 isPlanetaryBody: self.isPlanetaryBody(),
                 hipsBody: self.hipsBody,
+                requestCredentials: self.requestCredentials || 'omit',
+                requestMode: self.requestMode || 'cors',
             },
             meta: {
                 ...this.colorCfg.get(),

--- a/src/js/HiPSProperties.js
+++ b/src/js/HiPSProperties.js
@@ -69,7 +69,7 @@ HiPSProperties.fetchFromID = async function(ID) {
     }
 }
 
-HiPSProperties.fetchFromUrl = async function(urlOrId) {
+HiPSProperties.fetchFromUrl = async function(urlOrId, requestMode, requestCredentials) {
     let url;
 
     try {
@@ -102,8 +102,15 @@ HiPSProperties.fetchFromUrl = async function(urlOrId) {
 
 
     let init = {};
-    if (Utils.requestCORSIfNotSameOrigin(url)) {
+
+    if (requestMode) {
+        init = { mode: requestMode };
+    } else if (Utils.requestCORSIfNotSameOrigin(url)) {
         init = { mode: 'cors' };
+    }
+
+    if (requestCredentials) {
+        init.credentials = requestCredentials
     }
 
     let result = fetch(url, init)


### PR DESCRIPTION
Hi,

This PR adds the CORS and Credential options when loading a HiPS.

**Use case:**

- We want to be able to display a proprietary HiPS for a select group of users.
- The HiPS is accessible over the internet but is behind some form of authentication.
- For this we need to be able to set the CORS and Credentials options when requesting Aladin to load a HiPS.