### PR TITLE
Fix Circle intersectsBBox

### DIFF
--- a/src/js/DefaultActionsForContextMenu.js
+++ b/src/js/DefaultActionsForContextMenu.js
@@ -45,7 +45,6 @@ export let DefaultActionsForContextMenu = (function () {
         const a = aladinInstance;
 
         const selectObjects = (selection) => {
-            console.log(selection)
             a.view.selectObjects(selection);
         };
         return [

--- a/src/js/Footprint.js
+++ b/src/js/Footprint.js
@@ -251,7 +251,7 @@ export let Footprint= (function() {
                 return true;
             }
         }
-        return false;
+        return this.shapes.some((shape) => shape.intersectsBBox(x, y, w, h, view));
     };
 
     return Footprint;

--- a/src/js/Selector.js
+++ b/src/js/Selector.js
@@ -135,10 +135,12 @@ export class Selector {
                 }
                 // footprints
                 overlayItems = cat.getFootprints();
+
                 if (overlayItems) {
                     const {x, y, w, h} = selection.bbox();
                     for (var l = 0; l < overlayItems.length; l++) {
                         f = overlayItems[l];
+
                         if (f.intersectsBBox(x, y, w, h, view)) {
                             objListPerCatalog.push(f);
                         }

--- a/src/js/shapes/Circle.js
+++ b/src/js/shapes/Circle.js
@@ -328,9 +328,11 @@ export let Circle = (function() {
             return false;
         }
 
+        // compute the absolute distance between the middle of the bbox
+        // and the center of the circle 
         const circleDistance = {
-            x: Math.abs(centerXyview[0] - x),
-            y: Math.abs(centerXyview[1] - y)
+            x: Math.abs(centerXyview[0] - (x + w/2)),
+            y: Math.abs(centerXyview[1] - (y + h/2))
         };
 
         if (circleDistance.x > (w/2 + this.radius)) { return false; }

--- a/src/js/shapes/Circle.js
+++ b/src/js/shapes/Circle.js
@@ -322,10 +322,15 @@ export let Circle = (function() {
     };
 
     // From StackOverflow: https://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection
-    Circle.prototype.intersectsBBox = function(x, y, w, h) {
+    Circle.prototype.intersectsBBox = function(x, y, w, h, view) {
+        var centerXyview = view.aladin.world2pix(this.centerRaDec[0], this.centerRaDec[1]);
+        if (!centerXyview) {
+            return false;
+        }
+
         const circleDistance = {
-            x: Math.abs(this.center.x - x),
-            y: Math.abs(this.center.y - y)
+            x: Math.abs(centerXyview[0] - x),
+            y: Math.abs(centerXyview[1] - y)
         };
 
         if (circleDistance.x > (w/2 + this.radius)) { return false; }

--- a/src/js/shapes/Ellipse.js
+++ b/src/js/shapes/Ellipse.js
@@ -346,6 +346,7 @@ export let Ellipse = (function() {
 
     Ellipse.prototype.intersectsBBox = function(x, y, w, h) {
         // todo
+        return false;
     };
     
     return Ellipse;


### PR DESCRIPTION
The intersectsBBox implementation in Circle.js throws an exception when we have added a Circle that hasn't yet been drawn. `this.circle` is only set in the draw function if the world2pix returns pixels for the Circle. Moreover, `this.circle` is not set to `undefined` again in the draw function if the Circle moves out of the current view, so the `intersectsBBox` might also get some false positives. This should solve both these problems.

Here's a small code snippet that currently throws an exception (when run in the Spherical projection. It's fine if run in for example Mollweide, where the whole sky is always visible):

```
aladin.gotoRaDec(-50.0, -50.0)
aladin.setFoV(1.9);
const overlay = aladin.createOverlay({
  name : "my overlay",
  color : "red"
});
aladin.addOverlay(overlay);
var footprint = 'CIRCLE ICRS 50.5 9.5 0.5';
var polygon = A.footprintsFromSTCS(footprint);
overlay.addFootprints(polygon);
```