### PR TITLE
Allow GraphicOverlay.increaseBrightness() to accept named colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 3.8.0
 
+
+* [fix] Fix shape hover colors when overlay uses named color (increaseBrightness() accepts names now) <https://github.com/cds-astro/aladin-lite/issues/355>
 * [feat] Selected and hovered items (shapes, sources, ...) are rendered at last. <https://github.com/cds-astro/aladin-lite/issues/337>
 * [feat] Add selectionLineWidth option for shapes and catalogs. <https://github.com/cds-astro/aladin-lite/pull/354>
 * [fix] horizontal/vertical overlay lines appearing correctly <https://github.com/cds-astro/aladin-lite/issues/334>

--- a/src/js/Overlay.js
+++ b/src/js/Overlay.js
@@ -309,12 +309,15 @@ export let GraphicOverlay = (function() {
      *
      * @memberof GraphicOverlay
      *
-     * @param {string} hex - The color given in hexadecimal e.g. '#ffa0bb'
+     * @param {string} color - Any CSS color string (hex e.g. '#ffa0bb', rgb(), named color)
      * @param {number} percent - The percentage to increase the brightness of
      *
      * @returns {string} The new color given as an hexadecimal string
      */
-    GraphicOverlay.increaseBrightness = function(hex, percent){
+    GraphicOverlay.increaseBrightness = function(color, percent){
+        // Normalize the color to hex.
+        var hex = Color.standardizeColor(color);
+
         // strip the leading # if it's there
         hex = hex.replace(/^\s*#|\s*$/g, '');
 


### PR DESCRIPTION
Fixes #355 

This fix uses the already-existing `Color.standardizeColor()` to allow `GraphicOverlay.increaseBrightness()` to accept named colors.  This means that hover colors are now computed properly in overlays with named colors.

This video shows the new behavior of the script in #355:

https://github.com/user-attachments/assets/1e703508-40c1-4b06-92f8-2df16bcf3aa0

