### PR TITLE
Bugfix/380 window self change

### DIFF
--- a/src/js/gui/Button/ShareView.js
+++ b/src/js/gui/Button/ShareView.js
@@ -133,7 +133,5 @@ import { Utils } from "../../Utils";
             },
             tooltip: {content: 'You can share/export your view into many ways', position: {direction: 'top'}},
         }, aladin);
-
-        self = this;
     }
 }

--- a/src/js/gui/Input/LayerSelector.js
+++ b/src/js/gui/Input/LayerSelector.js
@@ -80,9 +80,7 @@ export class LayerSelector extends Input {
             ...options
         })
 
-        self = this;
-
-        LayerSelector.objects.push(self);
+        LayerSelector.objects.push(this);
     }
 };
 


### PR DESCRIPTION
This PR fixes code that alters `window.self`, which can break other scripts relying on `window.self` holding a reference to `window`.
See referenced bug report for further information.

Fixes #380 